### PR TITLE
Filter out empty paths from arg files

### DIFF
--- a/Sources/Mockolo/Executor.swift
+++ b/Sources/Mockolo/Executor.swift
@@ -138,7 +138,7 @@ class Executor {
         // If source file list exists, source files value will be overriden (see the usage in setupArguments above)
         if let srcList = arguments.get(sourceFileList) {
             let text = try? String(contentsOfFile: srcList, encoding: String.Encoding.utf8)
-            srcs = text?.components(separatedBy: "\n").map(fullPath)
+            srcs = text?.components(separatedBy: "\n").filter{!$0.isEmpty}.map(fullPath)
         } else {
             srcs = arguments.get(sourceFiles)?.map(fullPath)
         }
@@ -151,7 +151,7 @@ class Executor {
         // If dep file list exists, mock filepaths value will be overriden (see the usage in setupArguments above)
         if let depList = arguments.get(self.depFileList) {
             let text = try? String(contentsOfFile: depList, encoding: String.Encoding.utf8)
-            mockFilePaths = text?.components(separatedBy: "\n").map(fullPath)
+            mockFilePaths = text?.components(separatedBy: "\n").filter{!$0.isEmpty}.map(fullPath)
         } else {
              mockFilePaths = arguments.get(self.mockFilePaths)?.map(fullPath)
         }


### PR DESCRIPTION
Empty files makes the tool crash at `ProcessedTypeMapGenerator.swift:49`. The reason is that `String(contentsOfFile: srcList, encoding: String.Encoding.utf8)` returns an empty string if the file is empty and `components(separatedBy: "\n")` creates an array with a single empty element which can't be resolved to a path.