### PR TITLE
Update imports with swiftsyntax parse results

### DIFF
--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -42,6 +42,7 @@ struct ResolvedEntity {
 
 struct ResolvedEntityContainer {
     let entity: ResolvedEntity
+    let paths: [String]
     let imports: [(String, Data, Int64)]
 }
 

--- a/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
+++ b/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
@@ -25,7 +25,7 @@ func generateUniqueModels(protocolMap: [String: Entity],
                           typeKeys: [String: String]?,
                           semaphore: DispatchSemaphore?,
                           queue: DispatchQueue?,
-                          process: @escaping (ResolvedEntity, [(String, Data, Int64)]) -> ()) {
+                          process: @escaping (ResolvedEntityContainer) -> ()) {
     if let queue = queue {
         let lock = NSLock()
         for (key, val) in annotatedProtocolMap {
@@ -49,7 +49,7 @@ func generateUniqueModels(key: String,
                           protocolMap: [String: Entity],
                           inheritanceMap: [String: Entity]) -> ResolvedEntityContainer {
     
-    let (models, processedModels, attributes, pathToContentList) = lookupEntities(key: key, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
+    let (models, processedModels, attributes, paths, pathToContentList) = lookupEntities(key: key, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
     
     let processedFullNames = processedModels.compactMap {$0.fullName}
 
@@ -86,7 +86,7 @@ func generateUniqueModels(key: String,
     let whitelist = typealiasWhitelist(in: uniqueModels)
     let resolvedEntity = ResolvedEntity(key: key, entity: entity, uniqueModels: uniqueModels, attributes: attributes, hasInit: containsInit, initVars: initVars, typealiasWhitelist: whitelist)
     
-    return ResolvedEntityContainer(entity: resolvedEntity, imports: pathToContentList)
+    return ResolvedEntityContainer(entity: resolvedEntity, paths: paths, imports: pathToContentList)
 }
 
 
@@ -97,11 +97,11 @@ func generateUniqueModels(key: String,
                           protocolMap: [String: Entity],
                           inheritanceMap: [String: Entity],
                           lock: NSLock? = nil,
-                          process: @escaping (ResolvedEntity, [(String, Data, Int64)]) -> ()) {
+                          process: @escaping (ResolvedEntityContainer) -> ()) {
     let ret = generateUniqueModels(key: key, entity: entity, typeKeys: typeKeys, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
     
     lock?.lock()
-    process(ret.entity, ret.imports)
+    process(ret)
     lock?.unlock()
 }
 

--- a/Tests/TestOverloads/FixtureFuncOverload1.swift
+++ b/Tests/TestOverloads/FixtureFuncOverload1.swift
@@ -1,12 +1,16 @@
 import MockoloFramework
 
 let overload1 = """
+import AVFoundation
+
 /// \(String.mockAnnotation)
 protocol P1: P0 {
 }
 """
 
 let overloadParent1 = """
+import Foundation
+import CoreLocation
 
 public class P0Mock: P0 {
     private var _doneInit = false
@@ -36,6 +40,9 @@ public class P0Mock: P0 {
 
 let overloadMock1 =
 """
+import AVFoundation
+import CoreLocation
+import Foundation
 
 class P1Mock: P1 {
     


### PR DESCRIPTION
With SwiftSyntax, we no longer need to parse import lines manually, but can just keep track of filepaths that are relevant and look up the imported lines given the path later. 