### PR TITLE
Fix for swift keyword named closure params

### DIFF
--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -32,6 +32,9 @@ func applyClosureTemplate(name: String,
             if argType.typeName.hasPrefix(String.autoclosure) {
                 return argName + "()"
             }
+            if argName.isSwiftKeyword {
+                return "`\(argName)`"
+            }
             return argName
         }
         handlerParamValsStr = zipped.joined(separator: ", ")

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -43,6 +43,14 @@ extension String {
     static let `throws` = "throws"
     static let `rethrows` = "rethrows"
     static let `try` = "try"
+    static let `for` = "for"
+    static let `in` = "in"
+    static let `where` = "where"
+    static let `while` = "while"
+    static let `default` = "default"
+    static let `fallthrough` = "fallthrough"
+    static let `do` = "do"
+    static let `switch` = "switch"
     static let closureArrow = "->"
     static let typealiasColon = "typealias:"
     static let `typealias` = "typealias"
@@ -69,6 +77,23 @@ extension String {
 
     var isThrowsOrRethrows: Bool {
         return self == .throws || self == .rethrows
+    }
+
+    var isSwiftKeyword: Bool {
+        [
+            .for,
+            .throws,
+            .rethrows,
+            .try,
+            .for,
+            .in,
+            .where,
+            .while,
+            .default,
+            .fallthrough,
+            .do,
+            .switch
+        ].contains(self)
     }
 }
 

--- a/Tests/TestNonSimpleVars/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestNonSimpleVars/FixtureNonSimpleFuncs.swift
@@ -416,3 +416,71 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 }
 """
+
+let forArgClosureFunc = """
+import Foundation
+
+/// \(String.mockAnnotation)
+protocol NonSimpleFuncs {
+func max(for: Int) -> (() -> Void)?
+func maxDo(do: Int) -> (() -> Void)?
+func maxIn(in: Int) -> (() -> Void)?
+func maxSwitch(for switch: Int) -> (() -> Void)?
+}
+"""
+
+let forArgClosureFuncMock = """
+
+import Foundation
+
+
+class NonSimpleFuncsMock: NonSimpleFuncs {
+
+    private var _doneInit = false
+
+    init() {
+
+        _doneInit = true
+    }
+        var maxCallCount = 0
+    var maxHandler: ((Int) -> ((() -> Void)?))?
+    func max(for: Int) -> (() -> Void)? {
+        maxCallCount += 1
+
+        if let maxHandler = maxHandler {
+            return maxHandler(`for`)
+        }
+        return nil
+    }
+    var maxDoCallCount = 0
+    var maxDoHandler: ((Int) -> ((() -> Void)?))?
+    func maxDo(do: Int) -> (() -> Void)? {
+        maxDoCallCount += 1
+
+        if let maxDoHandler = maxDoHandler {
+            return maxDoHandler(`do`)
+        }
+        return nil
+    }
+    var maxInCallCount = 0
+    var maxInHandler: ((Int) -> ((() -> Void)?))?
+    func maxIn(in: Int) -> (() -> Void)? {
+        maxInCallCount += 1
+
+        if let maxInHandler = maxInHandler {
+            return maxInHandler(`in`)
+        }
+        return nil
+    }
+    var maxSwitchCallCount = 0
+    var maxSwitchHandler: ((Int) -> ((() -> Void)?))?
+    func maxSwitch(for switch: Int) -> (() -> Void)? {
+        maxSwitchCallCount += 1
+
+        if let maxSwitchHandler = maxSwitchHandler {
+            return maxSwitchHandler(`switch`)
+        }
+        return nil
+    }
+}
+"""

--- a/Tests/TestNonSimpleVars/NonSimpleCaseTests.swift
+++ b/Tests/TestNonSimpleVars/NonSimpleCaseTests.swift
@@ -25,14 +25,22 @@ class NonSimpleVarTests: MockoloTestCase {
                dstContent: variadicFuncMock,
                concurrencyLimit: nil)
     }
+
     func testAutoclosureArgFuncs() {
         verify(srcContent: autoclosureArgFunc,
                dstContent: autoclosureArgFuncMock,
                concurrencyLimit: nil)
     }
+
     func testClosureArgFuncs() {
         verify(srcContent: closureArgFunc,
                dstContent: closureArgFuncMock,
+               concurrencyLimit: nil)
+    }
+
+    func testForArgFuncs() {
+        verify(srcContent: forArgClosureFunc,
+               dstContent: forArgClosureFuncMock,
                concurrencyLimit: nil)
     }
 }


### PR DESCRIPTION
Fixes an issue where generated mock code using  the name `for` as a closure argument to a function. These changes make sure to correctly escape `for` in this situation and with other closure keyword arguments