### PR TITLE
Fix for `for` named closure params

### DIFF
--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -173,10 +173,10 @@ final class MethodModel: Model {
         let suffixLen = ast.offset + ast.length - suffixOffset
         if suffixLen > 0, suffixOffset > ast.bodyOffset - 1 {
             let suffixPart = data.toString(offset: suffixOffset, length: suffixLen).trimmingCharacters(in: CharacterSet.whitespacesAndNewlines)
-            if suffixPart.hasPrefix("\(String.rethrows)") {
-                self.suffix = String.rethrows
-            } else if suffixPart.hasPrefix("\(String.throws)") {
-                self.suffix = String.throws
+            if suffixPart.hasPrefix("\(String.SwiftKeywords.rethrows.rawValue)") {
+                self.suffix = String.SwiftKeywords.rethrows.rawValue
+            } else if suffixPart.hasPrefix("\(String.SwiftKeywords.throws.rawValue)") {
+                self.suffix = String.SwiftKeywords.throws.rawValue
             } else {
                 self.suffix = ""
             }

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -32,10 +32,7 @@ func applyClosureTemplate(name: String,
             if argType.typeName.hasPrefix(String.autoclosure) {
                 return argName + "()"
             }
-            if argName.isSwiftKeyword {
-                return "`\(argName)`"
-            }
-            return argName
+            return argName.safeName
         }
         handlerParamValsStr = zipped.joined(separator: ", ")
     }

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -30,7 +30,7 @@ func applyClosureTemplate(name: String,
         let zipped = zip(paramVals, paramTypes).map { (arg) -> String in
             let (argName, argType) = arg
             if argType.typeName.hasPrefix(String.autoclosure) {
-                return argName + "()"
+                return argName.safeName + "()"
             }
             return argName.safeName
         }
@@ -38,7 +38,7 @@ func applyClosureTemplate(name: String,
     }
     let handlerReturnDefault = renderReturnDefaultStatement(name: name, type: returnDefaultType, typeKeys: typeKeys)
 
-    let prefix = suffix.isThrowsOrRethrows ? String.try + " " : ""
+    let prefix = suffix.isThrowsOrRethrows ? String.SwiftKeywords.try.rawValue + " " : ""
     
     let returnStr = returnDefaultType.typeName.isEmpty ? "" : "return "
     let callExpr = "\(returnStr)\(prefix)\(name)(\(handlerParamValsStr))\(type.cast ?? "")"

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -32,6 +32,9 @@ func applyClosureTemplate(name: String,
             if argType.typeName.hasPrefix(String.autoclosure) {
                 return argName + "()"
             }
+            if argName.isSwiftKeyword {
+                return "`\(argName)`"
+            }
             return argName
         }
         handlerParamValsStr = zipped.joined(separator: ", ")

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -43,6 +43,14 @@ extension String {
     static let `throws` = "throws"
     static let `rethrows` = "rethrows"
     static let `try` = "try"
+    static let `for` = "for"
+    static let `in` = "in"
+    static let `where` = "where"
+    static let `while` = "while"
+    static let `default` = "default"
+    static let `fallthrough` = "fallthrough"
+    static let `do` = "do"
+    static let `switch` = "switch"
     static let closureArrow = "->"
     static let typealiasColon = "typealias:"
     static let `typealias` = "typealias"
@@ -69,6 +77,23 @@ extension String {
 
     var isThrowsOrRethrows: Bool {
         return self == .throws || self == .rethrows
+    }
+
+    var isSwiftKeyword: Bool {
+        [
+            .for,
+            .throws,
+            .rethrows,
+            .try,
+            .for,
+            .in,
+            .where,
+            .while,
+            .default,
+            .fallthrough,
+            .do,
+            .switch
+        ].contains(self)
     }
 }
 

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -79,8 +79,8 @@ extension String {
         return self == .throws || self == .rethrows
     }
 
-    var isSwiftKeyword: Bool {
-        [
+    var safeName: String {
+        let kewords: [String] = [
             .for,
             .throws,
             .rethrows,
@@ -93,7 +93,11 @@ extension String {
             .fallthrough,
             .do,
             .switch
-        ].contains(self)
+        ]
+        if kewords.contains(self) {
+            return "`\(self)`"
+        }
+        return self
     }
 }
 

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -17,6 +17,19 @@
 import Foundation
 
 extension String {
+    enum SwiftKeywords: String {
+        case `throws` = "throws"
+        case `rethrows` = "rethrows"
+        case `try` = "try"
+        case `for` = "for"
+        case `in` = "in"
+        case `where` = "where"
+        case `while` = "while"
+        case `default` = "default"
+        case `fallthrough` = "fallthrough"
+        case `do` = "do"
+        case `switch` = "switch"
+    }
     static let doneInit = "_doneInit"
     static let `static` = "static"
     static let `import` = "import "
@@ -40,17 +53,6 @@ extension String {
     static let observableEmpty = "Observable.empty()"
     static let rxObservableEmpty = "RxSwift.Observable.empty()"
     static let `required` = "required"
-    static let `throws` = "throws"
-    static let `rethrows` = "rethrows"
-    static let `try` = "try"
-    static let `for` = "for"
-    static let `in` = "in"
-    static let `where` = "where"
-    static let `while` = "while"
-    static let `default` = "default"
-    static let `fallthrough` = "fallthrough"
-    static let `do` = "do"
-    static let `switch` = "switch"
     static let closureArrow = "->"
     static let typealiasColon = "typealias:"
     static let `typealias` = "typealias"
@@ -76,25 +78,11 @@ extension String {
     """
 
     var isThrowsOrRethrows: Bool {
-        return self == .throws || self == .rethrows
+        return self == SwiftKeywords.throws.rawValue || self == SwiftKeywords.rethrows.rawValue
     }
 
     var safeName: String {
-        let kewords: [String] = [
-            .for,
-            .throws,
-            .rethrows,
-            .try,
-            .for,
-            .in,
-            .where,
-            .while,
-            .default,
-            .fallthrough,
-            .do,
-            .switch
-        ]
-        if kewords.contains(self) {
+        if let _ = SwiftKeywords(rawValue: self) {
             return "`\(self)`"
         }
         return self

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -466,7 +466,7 @@ public struct Type {
             displayableReturnType = "(\(displayableReturnType))"
         }
         
-        let suffixStr = suffix.isThrowsOrRethrows ? String.throws + " " : ""
+        let suffixStr = suffix.isThrowsOrRethrows ? String.SwiftKeywords.throws.rawValue + " " : ""
         
         let typeStr = "((\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType))?"
         return Type(typeStr, cast: returnTypeCast)

--- a/Tests/TestNonSimpleVars/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestNonSimpleVars/FixtureNonSimpleFuncs.swift
@@ -416,3 +416,71 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 }
 """
+
+let forArgClosureFunc = """
+import Foundation
+
+/// \(String.mockAnnotation)
+protocol NonSimpleFuncs {
+func max(for: Int) -> (() -> Void)?
+func maxDo(do: Int) -> (() -> Void)?
+func maxIn(in: Int) -> (() -> Void)?
+func maxSwitch(for switch: Int) -> (() -> Void)?
+}
+"""
+
+let forArgClosureFuncMock = """
+
+import Foundation
+
+
+class NonSimpleFuncsMock: NonSimpleFuncs {
+
+    private var _doneInit = false
+
+    init() {
+
+        _doneInit = true
+    }
+        var maxCallCount = 0
+    var maxHandler: ((Int) -> ((() -> Void)?))?
+    func max(for: Int) -> (() -> Void)? {
+        maxCallCount += 1
+
+        if let maxHandler = maxHandler {
+            return maxHandler(`for`)
+        }
+        return nil
+    }
+    var maxDoCallCount = 0
+    var maxDoHandler: ((Int) -> ((() -> Void)?))?
+    func maxDo(do: Int) -> (() -> Void)? {
+        maxDoCallCount += 1
+
+        if let maxDoHandler = maxDoHandler {
+            return maxDoHandler(`do`)
+        }
+        return nil
+    }
+    var maxInCallCount = 0
+    var maxInHandler: ((Int) -> ((() -> Void)?))?
+    func maxIn(in: Int) -> (() -> Void)? {
+        maxInCallCount += 1
+
+        if let maxInHandler = maxInHandler {
+            return maxInHandler(`in`)
+        }
+        return nil
+    }
+    var maxSwitchCallCount = 0
+    var maxSwitchHandler: ((Int) -> ((() -> Void)?))?
+    func maxSwitch(for switch: Int) -> (() -> Void)? {
+        maxSwitchCallCount += 1
+
+        if let maxSwitchHandler = maxSwitchHandler {
+            return maxSwitchHandler(`switch`)
+        }
+        return nil
+    }
+}
+"""

--- a/Tests/TestNonSimpleVars/NonSimpleCaseTests.swift
+++ b/Tests/TestNonSimpleVars/NonSimpleCaseTests.swift
@@ -25,14 +25,22 @@ class NonSimpleVarTests: MockoloTestCase {
                dstContent: variadicFuncMock,
                concurrencyLimit: nil)
     }
+
     func testAutoclosureArgFuncs() {
         verify(srcContent: autoclosureArgFunc,
                dstContent: autoclosureArgFuncMock,
                concurrencyLimit: nil)
     }
+
     func testClosureArgFuncs() {
         verify(srcContent: closureArgFunc,
                dstContent: closureArgFuncMock,
+               concurrencyLimit: nil)
+    }
+
+    func testForArgFuncs() {
+        verify(srcContent: forArgClosureFunc,
+               dstContent: forArgClosureFuncMock,
                concurrencyLimit: nil)
     }
 }


### PR DESCRIPTION
Fixes an issue where generated mock code using the name for as a closure argument to a function. These changes make sure to correctly escape for in this situation and with other closure keyword arguments