### PR TITLE
Tweak the log function to ensure it respects the log level

### DIFF
--- a/Sources/MockoloFramework/Utils/Logger.swift
+++ b/Sources/MockoloFramework/Utils/Logger.swift
@@ -30,9 +30,7 @@ public enum LogLevel: Int {
 }
 
 public func log(_ arg: Any..., level: LogLevel = .info) {
-    
-    guard level.rawValue <= minLogLevel else { return }
-    
+    guard level.rawValue >= minLogLevel else { return }
     switch level {
     case .info, .verbose:
         print(arg)


### PR DESCRIPTION
Needed a little tweak as setting `.warning` or `.error` did not take effect, and the logger still printed all the calls.
