### PR TITLE
Update order of log levels

### DIFF
--- a/Sources/MockoloFramework/Utils/Logger.swift
+++ b/Sources/MockoloFramework/Utils/Logger.swift
@@ -23,8 +23,8 @@ public var minLogLevel = 0
 
 /// Logs status and other messages depending on the level provided
 public enum LogLevel: Int {
-    case info
     case verbose
+    case info
     case warning
     case error
 }
@@ -44,13 +44,13 @@ public func log(_ arg: Any..., level: LogLevel = .info) {
 }
 
 public func signpost_begin(name: StaticString) {
-    if minLogLevel >= LogLevel.verbose.rawValue {
+    if minLogLevel == LogLevel.verbose.rawValue {
         os_signpost(.begin, log: perfLog, name: name)
     }
 }
 
 public func signpost_end(name: StaticString) {
-    if minLogLevel >= LogLevel.verbose.rawValue {
+    if minLogLevel == LogLevel.verbose.rawValue {
         os_signpost(.end, log: perfLog, name: name)
     }
 }


### PR DESCRIPTION
Resolves https://github.com/uber/mockolo/issues/93

Ensures `verbose` log level prints out more details than `info`. Updated signpost methods to be active only when `verbose` log level is used.  Signpost traces will not be collected for `info`, `warn`, and `error` levels.

I just realized that the current order is consistent with `OSLogType`, but that has been addressed in SwiftLog https://github.com/apple/swift-log/blob/master/Sources/Logging/Logging.swift which seems to be more aligned with loggers available in other languages (i.e. log4j in Java https://en.wikipedia.org/wiki/Log4j).

Signed-off-by: Marcin Iwanicki <marcin@iwanicki.me>