### PR TITLE
Use exact and appropriate versions of SwiftSyntax

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -1,6 +1,17 @@
 // swift-tools-version:5.1
 import PackageDescription
 
+var dependencies: [Package.Dependency] = [
+    .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
+    .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.26.0"),
+]
+
+#if swift(>=5.2)
+dependencies.append(.package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50200.0")))
+#elseif swift(>=5.1)
+dependencies.append(.package(url: "https://github.com/apple/swift-syntax.git", .exact("0.50100.0")))
+#endif
+
 let package = Package(
     name: "Mockolo",
     platforms: [
@@ -10,11 +21,7 @@ let package = Package(
         .executable(name: "mockolo", targets: ["Mockolo"]),
         .library(name: "MockoloFramework", targets: ["MockoloFramework"]),
         ],
-    dependencies: [
-        .package(url: "https://github.com/apple/swift-package-manager.git", .exact("0.5.0")),
-        .package(url: "https://github.com/jpsim/SourceKitten.git", from: "0.26.0"),
-        .package(url: "https://github.com/apple/swift-syntax.git", from: "0.50100.0"),
-        ],
+    dependencies: dependencies,
     targets: [
         .target(
             name: "Mockolo",


### PR DESCRIPTION
Since SwiftSyntax released `0.50200.0` for Xcode 11.4 [yesterday](https://github.com/apple/swift-syntax/releases/tag/0.50200.0), building mockolo in a clean environment started to fail with Xcode 11.3.x, as the version of SwiftSyntax is not pinned.

```
 › xcode-select -s /Applications/Xcode_11_3_1.app
 › rm -rf Package.resolved .build
 › swift build
Fetching https://github.com/apple/swift-package-manager.git
(...)
Completed resolution in 38.32s
Cloning https://github.com/apple/swift-syntax.git
Resolving https://github.com/apple/swift-syntax.git at 0.50200.0
(...)
```

This change pins and changes the version of SwiftSyntax for the language version, leads to successful build with Xcode 11.3.x.

```
 › xcode-select -s /Applications/Xcode_11_3_1.app
 › rm -rf Package.resolved .build
 › swift build
(...)
Cloning https://github.com/apple/swift-syntax.git
Resolving https://github.com/apple/swift-syntax.git at 0.50100.0
```

```
 › sudo xcode-select -s /Applications/Xcode_11_4.app
 › rm -rf Package.resolved .build
 › swift build
(...)
Cloning https://github.com/apple/swift-syntax.git
Resolving https://github.com/apple/swift-syntax.git at 0.50200.0
```

Still, building with Xcode 11.4 continues to fail as SwiftSyntax changed its API drastically. I'm also working on change for it.