### PR TITLE
[ReturnSelf] Allows Protocols to Return Self

### DIFF
--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -31,7 +31,7 @@ final class ClosureModel: Model {
     }
 
     
-    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type, encloser: String?) {
+    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type, encloser: String) {
         self.name = name + .handlerSuffix
         self.suffix = suffix
         let genericTypeNameList = genericTypeParams.map(path: \.name)

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -31,7 +31,7 @@ final class ClosureModel: Model {
     }
 
     
-    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type) {
+    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type, encloser: String?) {
         self.name = name + .handlerSuffix
         self.suffix = suffix
         let genericTypeNameList = genericTypeParams.map(path: \.name)
@@ -39,7 +39,7 @@ final class ClosureModel: Model {
         self.paramNames = paramNames
         self.paramTypes = paramTypes
         self.funcReturnType = returnType
-        self.type = Type.toClosureType(with: paramTypes, typeParams: genericTypeNameList, suffix: suffix, returnType: returnType)
+        self.type = Type.toClosureType(with: paramTypes, typeParams: genericTypeNameList, suffix: suffix, returnType: returnType, encloser: encloser)
     }
     
     func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, enableFuncArgsHistory: Bool = false) -> String? {

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -123,6 +123,7 @@ final class MethodModel: Model {
     init(name: String,
          typeName: String,
          kind: MethodKind,
+         encloser: String?,
          encloserType: DeclType,
          acl: String,
          genericTypeParams: [ParamModel],
@@ -135,7 +136,7 @@ final class MethodModel: Model {
          modelDescription: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
+        self.type = Type(typeName.trimmingCharacters(in: .whitespaces), encloser: encloser)
         self.suffix = throwsOrRethrows
         self.offset = offset
         self.length = length

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -40,7 +40,6 @@ final class MethodModel: Model {
     let suffix: String
     let kind: MethodKind
     let funcsWithArgsHistory: [String]
-    let encloser: String?
     var modelType: ModelType {
         return .method
     }
@@ -103,7 +102,7 @@ final class MethodModel: Model {
         return ret
     }()
 
-    lazy var handler: ClosureModel? = {
+    func handler(encloser: String) -> ClosureModel? {
         if isInitializer {
             return nil
         }
@@ -119,13 +118,12 @@ final class MethodModel: Model {
                                encloser: encloser)
         
         return ret
-    }()
+    }
     
     
     init(name: String,
          typeName: String,
          kind: MethodKind,
-         encloser: String?,
          encloserType: DeclType,
          acl: String,
          genericTypeParams: [ParamModel],
@@ -151,7 +149,6 @@ final class MethodModel: Model {
         self.funcsWithArgsHistory = funcsWithArgsHistory
         self.modelDescription = modelDescription
         self.accessLevel = acl
-        self.encloser = encloser
     }
     
     var fullName: String {
@@ -196,7 +193,7 @@ final class MethodModel: Model {
                                          accessLevel: accessLevel,
                                          suffix: suffix,
                                          argsHistory: argsHistory,
-                                         handler: handler)
+                                         handler: handler(encloser: encloser))
         return result
     }
 }

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -40,6 +40,7 @@ final class MethodModel: Model {
     let suffix: String
     let kind: MethodKind
     let funcsWithArgsHistory: [String]
+    let encloser: String?
     var modelType: ModelType {
         return .method
     }
@@ -114,7 +115,8 @@ final class MethodModel: Model {
                                paramNames: paramNames,
                                paramTypes: paramTypes,
                                suffix: suffix,
-                               returnType: type)
+                               returnType: type,
+                               encloser: encloser)
         
         return ret
     }()
@@ -136,7 +138,7 @@ final class MethodModel: Model {
          modelDescription: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.type = Type(typeName.trimmingCharacters(in: .whitespaces), encloser: encloser)
+        self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
         self.suffix = throwsOrRethrows
         self.offset = offset
         self.length = length
@@ -149,6 +151,7 @@ final class MethodModel: Model {
         self.funcsWithArgsHistory = funcsWithArgsHistory
         self.modelDescription = modelDescription
         self.accessLevel = acl
+        self.encloser = encloser
     }
     
     var fullName: String {

--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
@@ -146,7 +146,7 @@ extension MemberDeclListItemSyntax {
         return modifiers?.acl ?? ""
     }
     
-    func transformToModel(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool)? {
+    func transformToModel(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool, encloser: String?) -> (Model, String?, Bool)? {
         if let varMember = self.decl.as(VariableDeclSyntax.self) {
             if validateMember(varMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(varMember.modifiers, encloserAcl, declType)
@@ -157,13 +157,13 @@ extension MemberDeclListItemSyntax {
         } else if let funcMember = self.decl.as(FunctionDeclSyntax.self) {
             if validateMember(funcMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(funcMember.modifiers, encloserAcl, declType)
-                let item = funcMember.model(with: acl, declType: declType, encloser: encloser, funcsWithArgsHistory: metadata?.funcsWithArgsHistory, processed: processed)
+                let item = funcMember.model(with: acl, declType: declType, funcsWithArgsHistory: metadata?.funcsWithArgsHistory, processed: processed, encloser: encloser)
                 return (item, funcMember.attributes?.trimmedDescription, false)
             }
         } else if let subscriptMember = self.decl.as(SubscriptDeclSyntax.self) {
             if validateMember(subscriptMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(subscriptMember.modifiers, encloserAcl, declType)
-                let item = subscriptMember.model(with: acl, declType: declType, encloser: encloser, processed: processed)
+                let item = subscriptMember.model(with: acl, declType: declType, processed: processed)
                 return (item, subscriptMember.attributes?.trimmedDescription, false)
             }
         } else if let initMember = self.decl.as(InitializerDeclSyntax.self) {
@@ -181,7 +181,7 @@ extension MemberDeclListItemSyntax {
             let item = taMember.model(with: acl, declType: declType, overrides: metadata?.typeAliases, processed: processed)
             return (item, taMember.attributes?.trimmedDescription, false)
         } else if let ifMacroMember = self.decl.as(IfConfigDeclSyntax.self) {
-            let (item, attr, initFlag) = ifMacroMember.model(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed)
+            let (item, attr, initFlag) = ifMacroMember.model(with: encloserAcl, declType: declType, metadata: metadata, processed: processed)
             return (item, attr, initFlag)
         }
         
@@ -205,13 +205,13 @@ extension MemberDeclListSyntax {
         return false
     }
 
-    func memberData(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> EntityNodeSubContainer {
+    func memberData(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool, encloser: String?) -> EntityNodeSubContainer {
         var attributeList = [String]()
         var memberList = [Model]()
         var hasInit = false
 
         for m in self {
-            if let (item, attr, initFlag) = m.transformToModel(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed) {
+            if let (item, attr, initFlag) = m.transformToModel(with: encloserAcl, declType: declType, metadata: metadata, processed: processed, encloser: encloser) {
                 memberList.append(item)
                 if let attrDesc = attr {
                     attributeList.append(attrDesc)
@@ -224,7 +224,7 @@ extension MemberDeclListSyntax {
 }
 
 extension IfConfigDeclSyntax {
-    func model(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool) {
+    func model(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool) {
         var subModels = [Model]()
         var attrDesc: String?
         var hasInit = false
@@ -235,7 +235,7 @@ extension IfConfigDeclSyntax {
                 if let list = cl.elements.as(MemberDeclListSyntax.self) {
                     name = desc
                     for element in list {
-                        if let (item, attr, initFlag) = element.transformToModel(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed) {
+                        if let (item, attr, initFlag) = element.transformToModel(with: encloserAcl, declType: declType, metadata: metadata, processed: processed, encloser: nil) {
                             subModels.append(item)
                             if let attr = attr, attr.contains(String.available) {
                                 attrDesc = attr
@@ -260,7 +260,7 @@ extension ProtocolDeclSyntax: EntityNode {
     var encloser: String {
         return name + "Mock"
     }
-    
+
     var accessLevel: String {
         return self.modifiers?.acl ?? ""
     }
@@ -294,7 +294,7 @@ extension ProtocolDeclSyntax: EntityNode {
     }
     
     func subContainer(metadata: AnnotationMetadata?, declType: DeclType, path: String?, data: Data?, isProcessed: Bool) -> EntityNodeSubContainer {
-        return self.members.members.memberData(with: accessLevel, encloser: encloser, declType: declType, metadata: metadata, processed: isProcessed)
+        return self.members.members.memberData(with: accessLevel, declType: declType, metadata: metadata, processed: isProcessed, encloser: encloser)
     }
 }
 
@@ -345,7 +345,7 @@ extension ClassDeclSyntax: EntityNode {
     }
     
     func subContainer(metadata: AnnotationMetadata?, declType: DeclType, path: String?, data: Data?, isProcessed: Bool) -> EntityNodeSubContainer {
-        return self.members.members.memberData(with: accessLevel, encloser: nil, declType: declType, metadata: nil, processed: isProcessed)
+        return self.members.members.memberData(with: accessLevel, declType: declType, metadata: nil, processed: isProcessed, encloser: nil)
     }
 }
 
@@ -387,7 +387,7 @@ extension VariableDeclSyntax {
 }
 
 extension SubscriptDeclSyntax {
-    func model(with acl: String, declType: DeclType, encloser: String?, processed: Bool) -> Model {
+    func model(with acl: String, declType: DeclType, processed: Bool) -> Model {
         var isStatic = false
         if let modifiers = self.modifiers {
             isStatic = modifiers.isStatic
@@ -399,7 +399,7 @@ extension SubscriptDeclSyntax {
         let subscriptModel = MethodModel(name: self.subscriptKeyword.text,
                                          typeName: self.result.returnType.description,
                                          kind: .subscriptKind,
-                                         encloser: encloser,
+                                         encloser: nil,
                                          encloserType: declType,
                                          acl: acl,
                                          genericTypeParams: genericTypeParams,
@@ -417,7 +417,7 @@ extension SubscriptDeclSyntax {
 
 extension FunctionDeclSyntax {
     
-    func model(with acl: String, declType: DeclType, encloser: String?, funcsWithArgsHistory: [String]?, processed: Bool) -> Model {
+    func model(with acl: String, declType: DeclType, funcsWithArgsHistory: [String]?, processed: Bool, encloser: String?) -> Model {
         var isStatic = false
         if let modifiers = self.modifiers {
             isStatic = modifiers.isStatic

--- a/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/ViaSwiftSyntax/SwiftSyntaxExtensions.swift
@@ -146,7 +146,7 @@ extension MemberDeclListItemSyntax {
         return modifiers?.acl ?? ""
     }
     
-    func transformToModel(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool)? {
+    func transformToModel(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool)? {
         if let varMember = self.decl.as(VariableDeclSyntax.self) {
             if validateMember(varMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(varMember.modifiers, encloserAcl, declType)
@@ -157,13 +157,13 @@ extension MemberDeclListItemSyntax {
         } else if let funcMember = self.decl.as(FunctionDeclSyntax.self) {
             if validateMember(funcMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(funcMember.modifiers, encloserAcl, declType)
-                let item = funcMember.model(with: acl, declType: declType, funcsWithArgsHistory: metadata?.funcsWithArgsHistory, processed: processed)
+                let item = funcMember.model(with: acl, declType: declType, encloser: encloser, funcsWithArgsHistory: metadata?.funcsWithArgsHistory, processed: processed)
                 return (item, funcMember.attributes?.trimmedDescription, false)
             }
         } else if let subscriptMember = self.decl.as(SubscriptDeclSyntax.self) {
             if validateMember(subscriptMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(subscriptMember.modifiers, encloserAcl, declType)
-                let item = subscriptMember.model(with: acl, declType: declType, processed: processed)
+                let item = subscriptMember.model(with: acl, declType: declType, encloser: encloser, processed: processed)
                 return (item, subscriptMember.attributes?.trimmedDescription, false)
             }
         } else if let initMember = self.decl.as(InitializerDeclSyntax.self) {
@@ -181,7 +181,7 @@ extension MemberDeclListItemSyntax {
             let item = taMember.model(with: acl, declType: declType, overrides: metadata?.typeAliases, processed: processed)
             return (item, taMember.attributes?.trimmedDescription, false)
         } else if let ifMacroMember = self.decl.as(IfConfigDeclSyntax.self) {
-            let (item, attr, initFlag) = ifMacroMember.model(with: encloserAcl, declType: declType, metadata: metadata, processed: processed)
+            let (item, attr, initFlag) = ifMacroMember.model(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed)
             return (item, attr, initFlag)
         }
         
@@ -205,13 +205,13 @@ extension MemberDeclListSyntax {
         return false
     }
 
-    func memberData(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> EntityNodeSubContainer {
+    func memberData(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> EntityNodeSubContainer {
         var attributeList = [String]()
         var memberList = [Model]()
         var hasInit = false
 
         for m in self {
-            if let (item, attr, initFlag) = m.transformToModel(with: encloserAcl, declType: declType, metadata: metadata, processed: processed) {
+            if let (item, attr, initFlag) = m.transformToModel(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed) {
                 memberList.append(item)
                 if let attrDesc = attr {
                     attributeList.append(attrDesc)
@@ -224,7 +224,7 @@ extension MemberDeclListSyntax {
 }
 
 extension IfConfigDeclSyntax {
-    func model(with encloserAcl: String, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool) {
+    func model(with encloserAcl: String, encloser: String?, declType: DeclType, metadata: AnnotationMetadata?, processed: Bool) -> (Model, String?, Bool) {
         var subModels = [Model]()
         var attrDesc: String?
         var hasInit = false
@@ -235,7 +235,7 @@ extension IfConfigDeclSyntax {
                 if let list = cl.elements.as(MemberDeclListSyntax.self) {
                     name = desc
                     for element in list {
-                        if let (item, attr, initFlag) = element.transformToModel(with: encloserAcl, declType: declType, metadata: metadata, processed: processed) {
+                        if let (item, attr, initFlag) = element.transformToModel(with: encloserAcl, encloser: encloser, declType: declType, metadata: metadata, processed: processed) {
                             subModels.append(item)
                             if let attr = attr, attr.contains(String.available) {
                                 attrDesc = attr
@@ -255,6 +255,10 @@ extension IfConfigDeclSyntax {
 extension ProtocolDeclSyntax: EntityNode {
     var name: String {
         return identifier.text
+    }
+
+    var encloser: String {
+        return name + "Mock"
     }
     
     var accessLevel: String {
@@ -290,7 +294,7 @@ extension ProtocolDeclSyntax: EntityNode {
     }
     
     func subContainer(metadata: AnnotationMetadata?, declType: DeclType, path: String?, data: Data?, isProcessed: Bool) -> EntityNodeSubContainer {
-        return self.members.members.memberData(with: accessLevel, declType: declType, metadata: metadata, processed: isProcessed)
+        return self.members.members.memberData(with: accessLevel, encloser: encloser, declType: declType, metadata: metadata, processed: isProcessed)
     }
 }
 
@@ -341,7 +345,7 @@ extension ClassDeclSyntax: EntityNode {
     }
     
     func subContainer(metadata: AnnotationMetadata?, declType: DeclType, path: String?, data: Data?, isProcessed: Bool) -> EntityNodeSubContainer {
-        return self.members.members.memberData(with: accessLevel, declType: declType, metadata: nil, processed: isProcessed)
+        return self.members.members.memberData(with: accessLevel, encloser: nil, declType: declType, metadata: nil, processed: isProcessed)
     }
 }
 
@@ -383,7 +387,7 @@ extension VariableDeclSyntax {
 }
 
 extension SubscriptDeclSyntax {
-    func model(with acl: String, declType: DeclType, processed: Bool) -> Model {
+    func model(with acl: String, declType: DeclType, encloser: String?, processed: Bool) -> Model {
         var isStatic = false
         if let modifiers = self.modifiers {
             isStatic = modifiers.isStatic
@@ -395,6 +399,7 @@ extension SubscriptDeclSyntax {
         let subscriptModel = MethodModel(name: self.subscriptKeyword.text,
                                          typeName: self.result.returnType.description,
                                          kind: .subscriptKind,
+                                         encloser: encloser,
                                          encloserType: declType,
                                          acl: acl,
                                          genericTypeParams: genericTypeParams,
@@ -412,7 +417,7 @@ extension SubscriptDeclSyntax {
 
 extension FunctionDeclSyntax {
     
-    func model(with acl: String, declType: DeclType, funcsWithArgsHistory: [String]?, processed: Bool) -> Model {
+    func model(with acl: String, declType: DeclType, encloser: String?, funcsWithArgsHistory: [String]?, processed: Bool) -> Model {
         var isStatic = false
         if let modifiers = self.modifiers {
             isStatic = modifiers.isStatic
@@ -424,6 +429,7 @@ extension FunctionDeclSyntax {
         let funcmodel = MethodModel(name: self.identifier.description,
                                     typeName: self.signature.output?.returnType.description ?? "",
                                     kind: .funcKind,
+                                    encloser: encloser,
                                     encloserType: declType,
                                     acl: acl,
                                     genericTypeParams: genericTypeParams,
@@ -464,6 +470,7 @@ extension InitializerDeclSyntax {
         return MethodModel(name: "init",
                            typeName: "",
                            kind: .initKind(required: requiredInit, override: declType == .classType),
+                           encloser: nil,
                            encloserType: declType,
                            acl: acl,
                            genericTypeParams: genericTypeParams,

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -34,7 +34,7 @@ extension MethodModel {
         var template = ""
         
         let returnTypeName = returnType.isUnknown ? "" : returnType.typeName
-        
+
         let acl = accessLevel.isEmpty ? "" : accessLevel+" "
         let genericTypeDeclsStr = genericTypeParams.compactMap {$0.render(with: "", encloser: "")}.joined(separator: ", ")
         let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
@@ -142,4 +142,3 @@ extension MethodModel {
         return template
     }
 }
-

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -41,6 +41,7 @@ extension String {
 
     static let `inout` = "inout"
     static let hasBlankInit = "_hasBlankInit"
+    static let `Self` = "Self"
     static let `static` = "static"
     static let importSpace = "import "
     static public let `class` = "class"

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -27,8 +27,14 @@ public final class Type {
     let cast: String?
     var cachedDefaultVal: String?
 
-    init(_ type: String, cast: String? = nil){
-        self.typeName = type == .unknownVal ? "" : type
+    init(_ type: String, cast: String? = nil, encloser: String? = nil){
+        var typeNameStr = type
+        if type == .unknownVal {
+            typeNameStr = ""
+        } else if type == .`Self`, let encloser = encloser {
+            typeNameStr = encloser
+        }
+        self.typeName = typeNameStr
         self.cast = cast
     }
 

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -27,14 +27,8 @@ public final class Type {
     let cast: String?
     var cachedDefaultVal: String?
 
-    init(_ type: String, cast: String? = nil, encloser: String? = nil){
-        var typeNameStr = type
-        if type == .unknownVal {
-            typeNameStr = ""
-        } else if type == .`Self`, let encloser = encloser {
-            typeNameStr = encloser
-        }
-        self.typeName = typeNameStr
+    init(_ type: String, cast: String? = nil){
+        self.typeName = type == .unknownVal ? "" : type
         self.cast = cast
     }
 
@@ -505,7 +499,8 @@ public final class Type {
     }
 
 
-    static func toClosureType(with params: [Type], typeParams: [String], suffix: String, returnType: Type) -> Type {
+    static func toClosureType(with params: [Type], typeParams: [String], suffix: String, returnType: Type, encloser: String?) -> Type {
+
 
         let displayableParamTypes = params.map { (subtype: Type) -> String in
             return subtype.processTypeParams(with: typeParams)
@@ -513,6 +508,11 @@ public final class Type {
 
         let displayableParamStr = displayableParamTypes.joined(separator: ", ")
         var displayableReturnType = returnType.typeName
+
+        if let encloser = encloser, displayableReturnType == String.`Self` {
+            displayableReturnType = encloser
+        }
+
         let returnComps = displayableReturnType.literalComponents
 
         var returnAsStr = ""

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -513,10 +513,6 @@ public final class Type {
         let displayableParamStr = displayableParamTypes.joined(separator: ", ")
         var displayableReturnType = returnType.typeName
 
-        if returnType.isSelf {
-            displayableReturnType = encloser
-        }
-
         let returnComps = displayableReturnType.literalComponents
 
         var returnAsStr = ""
@@ -540,6 +536,11 @@ public final class Type {
             if !returnAsStr.isEmpty {
                 returnTypeCast = " as\(asSuffix) " + returnAsStr
             }
+        }
+
+         if returnType.isSelf {
+            displayableReturnType = encloser
+            returnTypeCast = " as! " + String.`Self`
         }
 
         let isSimpleTuple = displayableReturnType.hasPrefix("(") && displayableReturnType.hasSuffix(")") &&

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -129,6 +129,10 @@ public final class Type {
         return typeName.hasPrefix(String.escaping)
     }
 
+    var isSelf: Bool {
+        return typeName == String.`Self`
+    }
+
     var splitByClosure: Bool {
         let arg = typeName
         if let closureOpRange = arg.range(of: String.closureArrow) {
@@ -499,7 +503,7 @@ public final class Type {
     }
 
 
-    static func toClosureType(with params: [Type], typeParams: [String], suffix: String, returnType: Type, encloser: String?) -> Type {
+    static func toClosureType(with params: [Type], typeParams: [String], suffix: String, returnType: Type, encloser: String) -> Type {
 
 
         let displayableParamTypes = params.map { (subtype: Type) -> String in
@@ -509,7 +513,7 @@ public final class Type {
         let displayableParamStr = displayableParamTypes.joined(separator: ", ")
         var displayableReturnType = returnType.typeName
 
-        if let encloser = encloser, displayableReturnType == String.`Self` {
+        if returnType.isSelf {
             displayableReturnType = encloser
         }
 
@@ -527,6 +531,8 @@ public final class Type {
             } else if returnType.isIUO {
                 displayableReturnType = .any + "!"
                 returnAsStr.removeLast()
+            } else if returnType.isSelf {
+                returnAsStr = String.`Self`
             } else {
                 displayableReturnType = .any
             }

--- a/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
@@ -538,7 +538,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     func returnSelf() -> Self {
         returnSelfCallCount += 1
         if let returnSelfHandler = returnSelfHandler {
-            return returnSelfHandler()
+            return returnSelfHandler() as! Self
         }
         fatalError("returnSelfHandler returns can't have a default value thus its handler must be set")
     }

--- a/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
@@ -514,3 +514,33 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 }
 """
+
+let returnSelfFunc = """
+import Foundation
+
+/// \(String.mockAnnotation)
+protocol NonSimpleFuncs {
+@discardableResult
+func returnSelf() -> Self
+}
+"""
+
+let returnSelfFuncMock = """
+
+import Foundation
+
+
+class NonSimpleFuncsMock: NonSimpleFuncs {
+    init() { }
+
+    var returnSelfCallCount = 0
+    var returnSelfHandler: (() -> (NonSimpleFuncsMock))?
+    func returnSelf() -> NonSimpleFuncsMock {
+        returnSelfCallCount += 1
+        if let returnSelfHandler = returnSelfHandler {
+            return returnSelfHandler()
+        }
+        fatalError("returnSelfHandler returns can't have a default value thus its handler must be set")
+    }
+}
+"""

--- a/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestNonSimpleCases/FixtureNonSimpleFuncs.swift
@@ -87,7 +87,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     static subscript(key: Int) -> AnyObject? {
         get {
             subscriptCallCount += 1
-            
+
             if let subscriptHandler = subscriptHandler {
                 return subscriptHandler(key)
             }
@@ -100,7 +100,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(_ key: Int) -> AnyObject {
         get {
             subscriptKeyCallCount += 1
-            
+
             if let subscriptKeyHandler = subscriptKeyHandler {
                 return subscriptKeyHandler(key)
             }
@@ -113,7 +113,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(key: Int) -> AnyObject? {
         get {
             subscriptKeyIntCallCount += 1
-            
+
             if let subscriptKeyIntHandler = subscriptKeyIntHandler {
                 return subscriptKeyIntHandler(key)
             }
@@ -126,7 +126,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(index: String) -> CGImage? {
         get {
             subscriptIndexCallCount += 1
-            
+
             if let subscriptIndexHandler = subscriptIndexHandler {
                 return subscriptIndexHandler(index)
             }
@@ -139,7 +139,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(memoizeKey: Int) -> CGRect? {
         get {
             subscriptMemoizeKeyCallCount += 1
-            
+
             if let subscriptMemoizeKeyHandler = subscriptMemoizeKeyHandler {
                 return subscriptMemoizeKeyHandler(memoizeKey)
             }
@@ -152,7 +152,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(position: Int) -> Any {
         get {
             subscriptPositionCallCount += 1
-            
+
             if let subscriptPositionHandler = subscriptPositionHandler {
                 return subscriptPositionHandler(position)
             }
@@ -165,7 +165,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(index: String.Index) -> Double {
         get {
             subscriptIndexStringIndexCallCount += 1
-            
+
             if let subscriptIndexStringIndexHandler = subscriptIndexStringIndexHandler {
                 return subscriptIndexStringIndexHandler(index)
             }
@@ -178,7 +178,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(safe index: String.Index) -> Double? {
         get {
             subscriptSafeCallCount += 1
-            
+
             if let subscriptSafeHandler = subscriptSafeHandler {
                 return subscriptSafeHandler(index)
             }
@@ -191,7 +191,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(range: Range<Int>) -> String {
         get {
             subscriptRangeCallCount += 1
-            
+
             if let subscriptRangeHandler = subscriptRangeHandler {
                 return subscriptRangeHandler(range)
             }
@@ -204,7 +204,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript(path: String) -> ((Double) -> Float)? {
         get {
             subscriptPathCallCount += 1
-            
+
             if let subscriptPathHandler = subscriptPathHandler {
                 return subscriptPathHandler(path)
             }
@@ -217,7 +217,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T>(dynamicMember keyPath: ReferenceWritableKeyPath<Double, T>) -> T {
         get {
             subscriptDynamicMemberCallCount += 1
-            
+
             if let subscriptDynamicMemberHandler = subscriptDynamicMemberHandler {
                 return subscriptDynamicMemberHandler(keyPath) as! T
             }
@@ -230,7 +230,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T>(dynamicMember keyPath: ReferenceWritableKeyPath<String, T>) -> T {
         get {
             subscriptDynamicMemberTCallCount += 1
-            
+
             if let subscriptDynamicMemberTHandler = subscriptDynamicMemberTHandler {
                 return subscriptDynamicMemberTHandler(keyPath) as! T
             }
@@ -243,7 +243,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T>(dynamicMember keyPath: WritableKeyPath<T, Value>) -> Value {
         get {
             subscriptDynamicMemberTWritableKeyPathTValueCallCount += 1
-            
+
             if let subscriptDynamicMemberTWritableKeyPathTValueHandler = subscriptDynamicMemberTWritableKeyPathTValueHandler {
                 return subscriptDynamicMemberTWritableKeyPathTValueHandler(keyPath)
             }
@@ -256,7 +256,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<T: ExpressibleByIntegerLiteral>(_ parameter: T) -> T {
         get {
             subscriptParameterCallCount += 1
-            
+
             if let subscriptParameterHandler = subscriptParameterHandler {
                 return subscriptParameterHandler(parameter) as! T
             }
@@ -269,7 +269,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<Value>(keyPath: ReferenceWritableKeyPath<T, Value>) -> Array<Value> {
         get {
             subscriptKeyPathCallCount += 1
-            
+
             if let subscriptKeyPathHandler = subscriptKeyPathHandler {
                 return subscriptKeyPathHandler(keyPath) as! Array<Value>
             }
@@ -282,7 +282,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     subscript<Value>(keyPath: ReferenceWritableKeyPath<T, Value>, on schedulerType: T) -> Array<Value> {
         get {
             subscriptKeyPathOnCallCount += 1
-            
+
             if let subscriptKeyPathOnHandler = subscriptKeyPathOnHandler {
                 return subscriptKeyPathOnHandler(keyPath, schedulerType) as! Array<Value>
             }
@@ -294,11 +294,11 @@ class SubscriptProtocolMock: SubscriptProtocol {
 
 public class KeyValueSubscriptingMock: KeyValueSubscripting {
 
-    
-    
+
+
     public init() {
 
-        
+
     }
         public typealias Key = Any
     public typealias Value = Any
@@ -307,7 +307,7 @@ public class KeyValueSubscriptingMock: KeyValueSubscripting {
     public subscript(key: Key) -> Value? {
         get {
             subscriptCallCount += 1
-            
+
             if let subscriptHandler = subscriptHandler {
                 return subscriptHandler(key)
             }
@@ -320,7 +320,7 @@ public class KeyValueSubscriptingMock: KeyValueSubscripting {
     public subscript(key: Key, default defaultValue: @autoclosure () -> Value) -> Value {
         get {
             subscriptKeyCallCount += 1
-            
+
             if let subscriptKeyHandler = subscriptKeyHandler {
                 return subscriptKeyHandler(key, defaultValue())
             }
@@ -346,16 +346,16 @@ let variadicFuncMock =
 import Foundation
 
 class NonSimpleFuncsMock: NonSimpleFuncs {
-    
+
     init() {
-        
+
     }
-    
+
     var barCallCount = 0
     var barHandler: ((String, Int..., [Double]) -> (Float?))?
     func bar(_ arg: String, x: Int..., y: [Double]) -> Float? {
         barCallCount += 1
-        
+
         if let barHandler = barHandler {
             return barHandler(arg, x, y)
         }
@@ -380,19 +380,19 @@ import Foundation
 
 
 class NonSimpleFuncsMock: NonSimpleFuncs {
-    
-    
-    
+
+
+
     init() {
-        
-        
+
+
     }
-    
+
     var passCallCount = 0
     var passHandler: ((@autoclosure () -> Int) throws -> (Any))?
     func pass<T>(handler: @autoclosure () -> Int) rethrows -> T {
         passCallCount += 1
-        
+
         if let passHandler = passHandler {
             return try passHandler(handler()) as! T
         }
@@ -418,27 +418,27 @@ let closureArgFuncMock = """
 
 import Foundation
 class NonSimpleFuncsMock: NonSimpleFuncs {
-    
+
     init() {
-        
+
     }
-    
+
     var catCallCount = 0
     var catHandler: ((String, [String: String]?, () throws -> Any) throws -> (Any))?
     func cat<T>(named arg: String, tags: [String: String]?, closure: () throws -> T) rethrows -> T {
         catCallCount += 1
-        
+
         if let catHandler = catHandler {
             return try catHandler(arg, tags, closure) as! T
         }
         fatalError("catHandler returns can't have a default value thus its handler must be set")
     }
-    
+
     var moreCallCount = 0
     var moreHandler: ((String, [String: String]?, (Any) throws -> ()) throws -> (Any))?
     func more<T>(named arg: String, tags: [String: String]?, closure: (T) throws -> ()) rethrows -> T {
         moreCallCount += 1
-        
+
         if let moreHandler = moreHandler {
             return try moreHandler(arg, tags, closure) as! T
         }
@@ -466,11 +466,11 @@ import Foundation
 
 class NonSimpleFuncsMock: NonSimpleFuncs {
 
-    
+
 
     init() {
 
-        
+
     }
         var maxCallCount = 0
     var maxHandler: ((Int) -> ((() -> Void)?))?
@@ -535,7 +535,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
     var returnSelfCallCount = 0
     var returnSelfHandler: (() -> (NonSimpleFuncsMock))?
-    func returnSelf() -> NonSimpleFuncsMock {
+    func returnSelf() -> Self {
         returnSelfCallCount += 1
         if let returnSelfHandler = returnSelfHandler {
             return returnSelfHandler()

--- a/Tests/TestNonSimpleCases/NonSimpleCaseTests.swift
+++ b/Tests/TestNonSimpleCases/NonSimpleCaseTests.swift
@@ -37,4 +37,9 @@ class NonSimpleVarTests: MockoloTestCase {
         verify(srcContent: forArgClosureFunc,
                dstContent: forArgClosureFuncMock)
     }
+
+    func testReturnSelfFunc() {
+        verify(srcContent: returnSelfFunc,
+               dstContent: returnSelfFuncMock)
+    }
 }


### PR DESCRIPTION
Currently Mockolo is broken for Protocols that return Self. These changes ensure that we return the mock class type when we encounter a Self return type:

Example protocol that breaks Mockolo currently

```
/// @mockable
protocol NonSimpleFuncs {
    @discardableResult
    func returnSelf() -> Self
}
```