### PR TITLE
Update requirements in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ This project may contain unstable APIs which may not be ready for general use. S
 
 ## System Requirements
 
-* Swift 5.1 or later
-* Xcode 11.2 or later
+* Swift 5.2 or later
+* Xcode 11.4 or later
 * MacOS 10.14.6 or later
 * Support is included for the Swift Package Manager
 


### PR DESCRIPTION
Installation via _Homebrew_ requires _Xcode 11.4_ on the local machine. Seems like it was updated in [1.2.3](https://github.com/uber/mockolo/releases/tag/1.2.3) on June 9.