### PR TITLE
[#119] Attempts to fix Optional Generic Closures

### DIFF
--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -35,6 +35,10 @@ extension ClosureModel {
                 if argType.isInOut {
                     return "&" + argName.safeName
                 }
+                if argType.hasClosure && argType.isOptional,
+                    let renderedClosure = renderOptionalGenericClosure(argType: argType, argName: argName) {
+                    return renderedClosure
+                }
                 return argName.safeName
             }
             handlerParamValsStr = zipped.joined(separator: ", ")
@@ -69,5 +73,22 @@ extension ClosureModel {
             return "\(String.fatalError)(\"\(name) returns can't have a default value thus its handler must be set\")"
         }
         return  "return \(result)"
+    }
+
+    private func renderOptionalGenericClosure(
+        argType: Type,
+        argName: String
+    ) -> String? {
+        let literalComponents = argType.typeName.literalComponents
+        for genericTypeName in genericTypeNames {
+            if literalComponents.contains(genericTypeName) {
+                var processTypeParams = argType.processTypeParams(with: genericTypeNames)
+                let closureCast = processTypeParams.withoutTrailingCharacters(["!", "?"])
+                return argName.safeName +
+                    " as? " +
+                closureCast
+            }
+        }
+        return nil
     }
 }

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -135,7 +135,16 @@ extension String {
     var withRightParen: String {
         return "\(self))"
     }
-    
+
+    mutating func withoutTrailingCharacters(_ characters: [String]) -> String {
+        for character in characters {
+            if hasSuffix(character) {
+                _ = self.removeLast()
+            }
+        }
+        return self
+    }
+
 
     func canBeInitParam(type: String, isStatic: Bool) -> Bool {
         return !(isStatic || type == .unknownVal || (type.hasSuffix("?") && type.contains(String.closureArrow)) ||  isGenerated(type: Type(type)))

--- a/Tests/TestGenericFuncs/FixtureGenericFunc.swift
+++ b/Tests/TestGenericFuncs/FixtureGenericFunc.swift
@@ -49,6 +49,7 @@ protocol GenericFunc {
     func tell<BodyType: AnotherBody>(_ type: ResponseType, with handler: @escaping (BodyType) -> ()) -> Disposable
     func pull<T>(events: [SomeEvent], value: T, once: Bool, closure: @escaping (T?) -> ())
     func pull<U: ObservableType>(events: [SomeEvent], until: U?, closure: @escaping () -> ())
+    func optionalPull<T>(events: [SomeEvent], value: T, once: Bool, closure: ((T?) -> ())?)
     func add<T: FixedWidthInteger>(n1: T, n2: T?)
     func add<T: Sequence> (a: T?, b: T?)
     func add<T: Collection> (a: T, b: T)
@@ -131,6 +132,15 @@ class GenericFuncMock: GenericFunc {
         pullEventsCallCount += 1
         if let pullEventsHandler = pullEventsHandler {
             pullEventsHandler(events, until, closure)
+        }
+
+    }
+    var optionalPullCallCount = 0
+    var optionalPullHandler: (([SomeEvent], Any, Bool, ((Any?) -> ())?) -> ())?
+    func optionalPull<T>(events: [SomeEvent], value: T, once: Bool, closure: ((T?) -> ())?)  {
+        optionalPullCallCount += 1
+        if let optionalPullHandler = optionalPullHandler {
+            optionalPullHandler(events, value, once, closure as? ((Any?) -> ()))
         }
 
     }


### PR DESCRIPTION
Adds logic to handle a situation where we have a generic optional closure that the handler must cast to execute in the mock