### PR TITLE
Exclude escaping typealias handler from argument history capture.

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -15,7 +15,7 @@ final class ArgumentsHistoryModel: Model {
 
     init?(name: String, genericTypeParams: [ParamModel], params: [ParamModel], isHistoryAnnotated: Bool, suffix: String) {
         // Value contains closure is not supported.
-        let capturables = params.filter { !$0.type.hasClosure && !$0.type.isAutoclosure }
+        let capturables = params.filter { !$0.type.hasClosure && !$0.type.isEscaping && !$0.type.isAutoclosure }
         guard !capturables.isEmpty else {
             return nil
         }

--- a/Tests/TestArgumentsHistory/ArgumentsHistoryTests.swift
+++ b/Tests/TestArgumentsHistory/ArgumentsHistoryTests.swift
@@ -49,6 +49,12 @@ class ArgumentsHistoryTests: MockoloTestCase {
                dstContent: argumentsHistoryHandlerCaseMock,
                enableFuncArgsHistory: true)
     }
+
+    func testArgumentsHistoryEscapingTypealiasHandlerCase() {
+        verify(srcContent: argumentsHistoryEscapingTypealiasHandlerCase,
+               dstContent: argumentsHistoryEscapingTypealiasHandlerCaseMock,
+               enableFuncArgsHistory: true)
+    }
     
     func testArgumentsHistoryAutoclosureCase() {
         verify(srcContent: argumentsHistoryAutoclosureCase,

--- a/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
+++ b/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
@@ -386,6 +386,45 @@ class FooMock: Foo {
 }
 """
 
+let argumentsHistoryEscapingTypealiasHandlerCase = """
+typealias FooHandler = () -> Int
+typealias BarHandler = (String) -> Void
+
+/// \(String.mockAnnotation)
+protocol Foo {
+    func fooFunc(handler: @escaping FooHandler)
+    func barFunc(val: Int, handler: @escaping BarHandler)
+}
+"""
+
+let argumentsHistoryEscapingTypealiasHandlerCaseMock = """
+class FooMock: Foo {
+    init() { }
+
+    private(set) var fooFuncCallCount = 0
+    var fooFuncHandler: ((@escaping FooHandler) -> ())?
+    func fooFunc(handler: @escaping FooHandler) {
+        fooFuncCallCount += 1
+
+        if let fooFuncHandler = fooFuncHandler {
+            fooFuncHandler(handler)
+        }
+    }
+
+    private(set) var barFuncCallCount = 0
+    var barFuncArgValues = [Int]()
+    var barFuncHandler: ((Int, @escaping BarHandler) -> ())?
+    func barFunc(val: Int, handler: @escaping BarHandler) {
+        barFuncCallCount += 1
+        barFuncArgValues.append(val)
+
+        if let barFuncHandler = barFuncHandler {
+            barFuncHandler(val, handler)
+        }
+    }
+}
+"""
+
 let argumentsHistoryAutoclosureCase = """
 /// \(String.mockAnnotation)
 protocol Foo {


### PR DESCRIPTION
Changed to exclude Closure defined by typealias when creating ArgumentHistoryCapturable.

Currently, if Closure defined by typealias is in the argument, a Mock will be created as shown below and a compile error will occur.

```swift
typealias FooHandler = () -> Int
/// @mockable
protocol Foo {
    func fooFunc(handler: @escaping FooHandler)
}

class FooMock: Foo {
    ~
    var fooFuncArgValues = [@escaping FooHandler]() // <- error
    func fooFunc(handler: @escaping FooHandler) {
    }
    ~
}
```