### PR TITLE
Avoid writing to destination file if content is unchanged

### DIFF
--- a/Sources/MockoloFramework/Operations/OutputWriter.swift
+++ b/Sources/MockoloFramework/Operations/OutputWriter.swift
@@ -40,7 +40,12 @@ func write(candidates: [(String, Int64)],
         macroEnd = .poundEndIf
     }
     let ret = [headerStr, macroStart, imports, entities.joined(separator: "\n"), macroEnd].joined(separator: "\n\n")
-    
+    let currentFileContents = try? String(contentsOfFile: outputFilePath, encoding: .utf8)
+    guard currentFileContents != ret else {
+        log("Not writing the file as content is unchanged", level: .info)
+        return ret
+    }
+
     _ = try? ret.write(toFile: outputFilePath, atomically: true, encoding: .utf8)
     return ret
 }

--- a/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
@@ -1,4 +1,5 @@
 import Foundation
+import XCTest
 
 class BasicFuncTests: MockoloTestCase {
 
@@ -47,6 +48,25 @@ class BasicFuncTests: MockoloTestCase {
         verify(srcContent: simpleFuncs,
                dstContent: simpleMockFuncMock,
                useTemplateFunc: true)
+    }
+
+    func testFileWriteBehavior() throws {
+        verify(srcContent: simpleFuncs,
+               dstContent: simpleFuncsMock)
+
+        let expectedAttributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let expectedCreationDate = (expectedAttributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
+        let expectedModificationDate = (expectedAttributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
+
+        verify(srcContent: simpleFuncs,
+               dstContent: simpleFuncsMock)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let creationDate = (attributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
+        let modificationDate = (attributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
+
+        XCTAssertEqual(creationDate, expectedCreationDate)
+        XCTAssertEqual(modificationDate, expectedModificationDate)
     }
 }
 

--- a/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
@@ -1,5 +1,4 @@
 import Foundation
-import XCTest
 
 class BasicFuncTests: MockoloTestCase {
 
@@ -48,25 +47,6 @@ class BasicFuncTests: MockoloTestCase {
         verify(srcContent: simpleFuncs,
                dstContent: simpleMockFuncMock,
                useTemplateFunc: true)
-    }
-
-    func testFileWriteBehavior() throws {
-        verify(srcContent: simpleFuncs,
-               dstContent: simpleFuncsMock)
-
-        let expectedAttributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
-        let expectedCreationDate = (expectedAttributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
-        let expectedModificationDate = (expectedAttributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
-
-        verify(srcContent: simpleFuncs,
-               dstContent: simpleFuncsMock)
-
-        let attributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
-        let creationDate = (attributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
-        let modificationDate = (attributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
-
-        XCTAssertEqual(creationDate, expectedCreationDate)
-        XCTAssertEqual(modificationDate, expectedModificationDate)
     }
 }
 

--- a/Tests/TestOutputChange/OutputChangeTests.swift
+++ b/Tests/TestOutputChange/OutputChangeTests.swift
@@ -1,0 +1,23 @@
+import Foundation
+import XCTest
+
+class OutputChangeTests: MockoloTestCase {
+    func testFileWriteBehavior() throws {
+        verify(srcContent: simpleFuncs,
+               dstContent: simpleFuncsMock)
+
+        let expectedAttributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let expectedCreationDate = (expectedAttributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
+        let expectedModificationDate = (expectedAttributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
+
+        verify(srcContent: simpleFuncs,
+               dstContent: simpleFuncsMock)
+
+        let attributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let creationDate = (attributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
+        let modificationDate = (attributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
+
+        XCTAssertEqual(creationDate, expectedCreationDate)
+        XCTAssertEqual(modificationDate, expectedModificationDate)
+    }
+}


### PR DESCRIPTION
Resolves: #131 

As proposed in #131, this PR adapts the `write` method to only write the destination file if its content did not change. ~In the [equivalent PR](https://github.com/uber/needle/pull/382) for `needle` I was able to add a unit test for the file write behavior, but `mockolo` doesn't depend on https://github.com/uber/swift-common, so I wasn't able to leverage the `UnitTestLogger`. Do you have any other ideas of how to test the file write behavior?~

**Update:**
I also added a test that compares the [`.creationDate`](https://developer.apple.com/documentation/foundation/fileattributekey/1418187-creationdate) and [`.modificationDate`](https://developer.apple.com/documentation/foundation/fileattributekey/1410058-modificationdate) when calling `write` repeatedly. If you have any suggestions for a better location of this test, please let me know.