### PR TITLE
Fix class mock variable generation

### DIFF
--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -41,7 +41,7 @@ extension VariableModel {
         }
         
         var assignVal = ""
-        if let val = underlyingVarDefaultVal {
+        if !shouldOverride, let val = underlyingVarDefaultVal {
             assignVal = "= \(val)"
         }
         

--- a/Tests/TestClassMocking/FixtureMockableClass.swift
+++ b/Tests/TestClassMocking/FixtureMockableClass.swift
@@ -118,10 +118,10 @@ public class LowMock: Low {
 
 
     private(set) var nameSetCallCount = 0
-    override var name: String = "" { didSet { nameSetCallCount += 1 } }
+    override var name: String { didSet { nameSetCallCount += 1 } }
 
     private(set) var whatSetCallCount = 0
-    override var what: Float = 0.0 { didSet { whatSetCallCount += 1 } }
+    override var what: Float { didSet { whatSetCallCount += 1 } }
 
     private(set) var barCallCount = 0
     var barHandler: (() -> ())?
@@ -161,10 +161,10 @@ public class LowMock: Low {
 
 
     private(set) var nameSetCallCount = 0
-    override var name: String = "" { didSet { nameSetCallCount += 1 } }
+    override var name: String { didSet { nameSetCallCount += 1 } }
 
     private(set) var whatSetCallCount = 0
-    override var what: Float = 0.0 { didSet { whatSetCallCount += 1 } }
+    override var what: Float { didSet { whatSetCallCount += 1 } }
 
     private(set)  var barCallCount = 0
     var barHandler: (() -> ())?

--- a/Tests/TestClassMocking/FixtureMockableClassInit.swift
+++ b/Tests/TestClassMocking/FixtureMockableClassInit.swift
@@ -82,7 +82,7 @@ public class LowMock: Low {
     }
 
     private(set) var nameSetCallCount = 0
-    override var name: String = "" { didSet { nameSetCallCount += 1 } }
+    override var name: String { didSet { nameSetCallCount += 1 } }
 }
 """
 
@@ -104,6 +104,6 @@ public class LowMock: Low {
     }
 
     private(set) var nameSetCallCount = 0
-    override var name: String = "" { didSet { nameSetCallCount += 1 } }
+    override var name: String { didSet { nameSetCallCount += 1 } }
 }
 """


### PR DESCRIPTION
When a stored property is overridden with both:

- assigning default value
- attaching property observers (willSet/didSet)

that leads to the compile error of "Variable with getter/setter cannot have an initial value".

ref: https://stackoverflow.com/a/33641878/3068179

> Looks like this doesn't work when overriding inherited properties. Here is an example of what you can't do:

```swift
class StepWihtoutCounter {
    var totalSteps: Int = 0 
}

class StepCounter: StepWihtoutCounter {
    override var totalSteps: Int = 0 {
        willSet(newTotalSteps) {
            print("About to set totalSteps to \(newTotalSteps)")
        }
        didSet {
            if totalSteps > oldValue  {
                print("Added \(totalSteps - oldValue) steps")
            }
        }
    }
}
```