### PR TITLE
Support Swift 5.4

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,7 +18,7 @@ let package = Package(
         ],
     dependencies: dependencies,
     targets: [
-        .target(
+        .executableTarget(
             name: "Mockolo",
             dependencies: [
                 "MockoloFramework",

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.3
+// swift-tools-version:5.4
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [
@@ -6,7 +6,7 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.1.5")),
 ]
 
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.3-RELEASE")))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.4-RELEASE")))
 
 let package = Package(
     name: "Mockolo",

--- a/Package.swift
+++ b/Package.swift
@@ -1,12 +1,11 @@
 // swift-tools-version:5.4
 import PackageDescription
 
-var dependencies: [Package.Dependency] = [
+let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.1.5")),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.4-RELEASE")),
 ]
-
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.4-RELEASE")))
 
 let package = Package(
     name: "Mockolo",


### PR DESCRIPTION
## Issue

- close #142 

## References

- https://developer.apple.com/documentation/xcode-release-notes/xcode-12_5-release-notes

> Swift packages that specify a 5.4 tools version can now explicitly declare targets as executable, which allows the use of the @main keyword in package code. ([SE-0294](https://forums.swift.org/t/se-0294-declaring-executable-targets-in-package-manifests/42404), 47691185)