### PR TITLE
Add SwiftSyntax as described in the README

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -4,7 +4,7 @@ import PackageDescription
 let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.1.5")),
-    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("swift-5.4-RELEASE")),
+    .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
 ]
 
 let package = Package(


### PR DESCRIPTION
## Overview

When I add Mockolo to a package, I get the following error:

```
Dependencies could not be resolved because package 'mockolo' is required using a stable-version but 'mockolo' depends on an unstable-version package 'swift-syntax' and root depends on 'mockolo' 1.4.0.
```

We can solve this problem by adding SwiftSyntax as described in its README.  
ref: https://github.com/apple/swift-syntax#declare-swiftpm-dependency-with-release-tag