### PR TITLE
Remove Swift Argument Parser since it is not used.

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,6 @@
 import PackageDescription
 
 let dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-argument-parser", .upToNextMinor(from: "0.0.4")),
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.1.5")),
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
 ]
@@ -22,7 +21,6 @@ let package = Package(
             name: "Mockolo",
             dependencies: [
                 "MockoloFramework",
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
                 ]),
         .target(


### PR DESCRIPTION
## Overview

Remove Swift Argument Parser since it is not used.
It is preferable to replace swift-tools-support-core in the future.

## References

- https://github.com/apple/swift-argument-parser/issues/5
- https://github.com/apple/swift-tools-support-core/pull/194