### PR TITLE
Replace ArgumentParser with swift-argument-parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,7 @@ import PackageDescription
 
 let dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.1.5")),
+    .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.4.3")),
     .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")),
 ]
 
@@ -22,6 +23,7 @@ let package = Package(
             dependencies: [
                 "MockoloFramework",
                 .product(name: "SwiftToolsSupport-auto", package: "swift-tools-support-core"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser"),
                 ]),
         .target(
             name: "MockoloFramework",

--- a/Sources/Mockolo/Executor.swift
+++ b/Sources/Mockolo/Executor.swift
@@ -15,133 +15,111 @@
 //
 
 import Foundation
-import TSCUtility
 import MockoloFramework
+import ArgumentParser
 
-class Executor {
-    let defaultTimeout = 20
-    
+
+struct Executor: ParsableCommand {
+    static var configuration = CommandConfiguration(commandName: "mockolo", abstract: "Mockolo: Swift mock generator.")
+
+    let defaultTimeout: Int
+
     // MARK: - Private
-    private var loggingLevel: OptionArgument<Int>!
-    private var outputFilePath: OptionArgument<String>!
-    private var mockFileList: OptionArgument<String>!
-    private var mockFilePaths: OptionArgument<[String]>!
-    private var sourceDirs: OptionArgument<[String]>!
-    private var sourceFiles: OptionArgument<[String]>!
-    private var sourceFileList: OptionArgument<String>!
-    private var exclusionSuffixes: OptionArgument<[String]>!
-    private var header: OptionArgument<String>!
-    private var macro: OptionArgument<String>!
-    private var testableImports: OptionArgument<[String]>!
-    private var customImports: OptionArgument<[String]>!
-    private var excludeImports: OptionArgument<[String]>!
-    private var annotation: OptionArgument<String>!
-    private var useTemplateFunc: OptionArgument<Bool>!
-    private var useMockObservable: OptionArgument<Bool>!
-    private var mockAll: OptionArgument<Bool>!
-    private var mockFinal: OptionArgument<Bool>!
-    private var concurrencyLimit: OptionArgument<Int>!
-    private var enableArgsHistory: OptionArgument<Bool>!
-    private var allowSetCallCount: OptionArgument<Bool>!
-    
+    @Flag(name: .long,
+            help: "If set, generated *CallCount vars will be allowed to set manually.")
+    private var allowSetCallCount: Bool = false
 
-    /// Initializer.
-    ///
-    /// - parameter name: The name used to check if this command should
-    /// be executed.
-    /// - parameter overview: The overview description of this command.
-    /// - parameter parser: The argument parser to use.
-    init(parser: ArgumentParser) {
-        setupArguments(with: parser)
-    }
+    @Option(help: "A custom annotation string used to indicate if a type should be mocked (default = @mockable).")
+    private var annotation: String = String.mockAnnotation
+
+    @Option(name: [.customShort("j"), .long],
+            help: ArgumentHelp(
+                "Maximum number of threads to execute concurrently (default = number of cores on the running machine).",
+                valueName: "n"))
+    private var concurrencyLimit: Int?
+
+    @Option(help: "If set, custom module imports will be added to the final import statement list.")
+    private var customImports: [String] = []
+
+    @Flag(name: .long,
+            help: "Whether to enable args history for all functions (default = false). To enable history per function, use the 'history' keyword in the annotation argument.")
+    private  var enableArgsHistory: Bool = false
+
+    @Option(name: .long,
+            help: "If set, listed modules will be excluded from the import statements in the mock output.")
+    private  var excludeImports: [String] = []
+
+    @Option(name: [.customShort("x"), .customLong("exclude-suffixes")],
+            help: "List of filename suffix(es) without the file extensions to exclude from parsing (separated by a comma or a space).",
+            completion: .file())
+    private var exclusionSuffixes: [String] = []
+
+    @Option(name: .long,
+            help: "A custom header documentation to be added to the beginning of a generated mock file.")
+    private var header: String?
+
+    private static let validLoggingLevels = [0, 1, 2, 3]
+    @Option(name: [.short, .long],
+            help: ArgumentHelp(
+                "The logging level to use. Default is set to 0 (info only). Set 1 for verbose, 2 for warning, and 3 for error.",
+            valueName: "n"))
+    private var loggingLevel: Int = 0
+
+    @Option(help: "If set, #if [macro] / #endif will be added to the generated mock file content to guard compilation.")
+    private var macro: String?
+
+    @Flag(name: .long,
+            help: "If set, it will mock all types (protocols and classes) with a mock annotation (default is set to false and only mocks protocols with a mock annotation).")
+    private var mockAll: Bool = false
+
+    @Option(name: .customLong("mock-filelist"),
+            help: "Path to a file containing a list of dependent files (separated by a new line) of modules this target depends on.",
+            completion: .file())
+    private var mockFileList: String?
+
+    @Flag(name: .long,
+            help: "If set, generated mock classes will have the 'final' attributes (default is set to false).")
+    private var mockFinal: Bool = false
+
+    @Option(name: [.customLong("mocks", withSingleDash: true), .customLong("mockfiles")],
+            help: "List of mock files (separated by a comma or a space) from modules this target depends on. If the --mock-filelist value exists, this will be ignored.",
+            completion: .file())
+    private var mockFilePaths: [String] = []
+
+    @Option(name: [.customShort("d"), .customLong("destination")],
+            help: "Output file path containing the generated Swift mock classes. If no value is given, the program will exit.",
+            completion: .file())
+    private var outputFilePath: String
     
-    /// Setup the arguments using the given parser.
-    ///
-    /// - parameter parser: The argument parser to use.
-    private func setupArguments(with parser: ArgumentParser) {
-        
-        loggingLevel = parser.add(option: "--logging-level",
-                                  shortName: "-l",
-                                  kind: Int.self,
-                                  usage: "The logging level to use. Default is set to 0 (info only). Set 1 for verbose, 2 for warning, and 3 for error.")
-        sourceFiles = parser.add(option: "--sourcefiles",
-                                 shortName: "-srcs",
-                                 kind: [String].self,
-                                 usage: "List of source files (separated by a comma or a space) to generate mocks for. If the --sourcedirs or --filelist value exists, this will be ignored. ",
-                                 completion: .filename)
-        sourceFileList = parser.add(option: "--filelist",
-                                 shortName: "-f",
-                                 kind: String.self,
-                                 usage: "Path to a file containing a list of source file paths (delimited by a new line). If the --sourcedirs value exists, this will be ignored. ",
-                                 completion: .filename)
-        sourceDirs = parser.add(option: "--sourcedirs",
-                                shortName: "-s",
-                                kind: [String].self,
-                                usage: "Paths to the directories containing source files to generate mocks for. If the --filelist or --sourcefiles values exist, they will be ignored. ",
-                                completion: .filename)
-        mockFileList = parser.add(option: "--mock-filelist",
-                                   kind: String.self,
-                                   usage: "Path to a file containing a list of dependent files (separated by a new line) of modules this target depends on.",
-                                   completion: .filename)
-        mockFilePaths = parser.add(option: "--mockfiles",
-                                   shortName: "-mocks",
-                                   kind: [String].self,
-                                   usage: "List of mock files (separated by a comma or a space) from modules this target depends on. If the --mock-filelist value exists, this will be ignored.",
-                                   completion: .filename)
-        outputFilePath = parser.add(option: "--destination",
-                                    shortName: "-d",
-                                    kind: String.self,
-                                    usage: "Output file path containing the generated Swift mock classes. If no value is given, the program will exit.",
-                                    completion: .filename)
-        exclusionSuffixes = parser.add(option: "--exclude-suffixes",
-                                       shortName: "-x",
-                                       kind: [String].self,
-                                       usage: "List of filename suffix(es) without the file extensions to exclude from parsing (separated by a comma or a space).",
-                                       completion: .filename)
-        annotation = parser.add(option: "--annotation",
-                                shortName: "-a",
-                                kind: String.self,
-                                usage: "A custom annotation string used to indicate if a type should be mocked (default = @mockable).")
-        macro = parser.add(option: "--macro",
-                                shortName: "-m",
-                                kind: String.self,
-                                usage: "If set, #if [macro] / #endif will be added to the generated mock file content to guard compilation.")
-        testableImports = parser.add(option: "--testable-imports",
-                                        shortName: "-i",
-                                        kind: [String].self,
-                                        usage: "If set, @testable import statments will be added for each module name in this list.")
-        customImports = parser.add(option: "--custom-imports",
-                                        shortName: "-c",
-                                        kind: [String].self,
-                                        usage: "If set, custom module imports will be added to the final import statement list.")
-        excludeImports = parser.add(option: "--exclude-imports",
-                                        kind: [String].self,
-                                        usage: "If set, listed modules will be excluded from the import statements in the mock output.")
-        header = parser.add(option: "--header",
-                                kind: String.self,
-                                usage: "A custom header documentation to be added to the beginning of a generated mock file.")
-        useTemplateFunc = parser.add(option: "--use-template-func",
-                                 kind: Bool.self,
-                                 usage: "If set, a common template function will be called from all functions in mock classes (default is set to false).")
-        useMockObservable = parser.add(option: "--use-mock-observable",
-                                 kind: Bool.self,
-                                 usage: "If set, a property wrapper will be used to mock RxSwift Observable variables (default is set to false).")
-        mockAll = parser.add(option: "--mock-all",
-                                 kind: Bool.self,
-                                 usage: "If set, it will mock all types (protocols and classes) with a mock annotation (default is set to false and only mocks protocols with a mock annotation).")
-        mockFinal = parser.add(option: "--mock-final",
-                                 kind: Bool.self,
-                                 usage: "If set, generated mock classes will have the 'final' attributes (default is set to false).")
-        concurrencyLimit = parser.add(option: "--concurrency-limit",
-                                      shortName: "-j",
-                                      kind: Int.self,
-                                      usage: "Maximum number of threads to execute concurrently (default = number of cores on the running machine).")
-        allowSetCallCount = parser.add(option: "--allow-set-callcount",
-                                       kind: Bool.self,
-                                       usage: "If set, generated *CallCount vars will be allowed to set manually. ")
-        enableArgsHistory = parser.add(option: "--enable-args-history",
-                                       kind: Bool.self,
-                                       usage: "Whether to enable args history for all functions (default = false). To enable history per function, use the 'history' keyword in the annotation argument. ")
+    @Option(name: [.customShort("s"), .customLong("sourcedirs")],
+            help: "Paths to the directories containing source files to generate mocks for. If the --filelist or --sourcefiles values exist, they will be ignored.",
+            completion: .file())
+    private var sourceDirs: [String] = []
+
+    @Option(name: [.customShort("f"), .customLong("filelist")],
+            help: "Path to a file containing a list of source file paths (delimited by a new line). If the --sourcedirs value exists, this will be ignored.",
+            completion: .file())
+    private var sourceFileList: String?
+
+    @Option(name: [.customLong("srcs", withSingleDash: true), .customLong("sourcefiles")],
+            help: "List of source files (separated by a comma or a space) to generate mocks for. If the --sourcedirs or --filelist value exists, this will be ignored.",
+            completion: .file())
+    private var sourceFiles: [String] = []
+
+    @Option(name: [.long, .customShort("i")],
+            help: "If set, @testable import statements will be added for each module name in this list.")
+    private var testableImports: [String] = []
+
+    @Flag(name: .long,
+            help: "If set, a property wrapper will be used to mock RxSwift Observable variables (default is set to false).")
+    private var useMockObservable: Bool = false
+
+    @Flag(name: .long,
+            help: "If set, a common template function will be called from all functions in mock classes (default is set to false).")
+    private var useTemplateFunc: Bool = false
+    
+    init() {
+        self.defaultTimeout = 20
     }
     
     private func fullPath(_ path: String) -> String {
@@ -154,54 +132,46 @@ class Executor {
         }
         return FileManager.default.currentDirectoryPath + "/" + path
     }
-    
-    
-    /// Execute the command.
-    ///
-    /// - parameter arguments: The command line arguments to execute the command with.
-    func execute(with arguments: ArgumentParser.Result) {
-        guard let outputArg = arguments.get(outputFilePath) else { fatalError("Missing destination file path") }
-        let outputFilePath = fullPath(outputArg)
 
-        let srcDirs = arguments.get(sourceDirs)?.map(fullPath)
-        var srcs: [String]?
+    mutating func validate() throws {
+        guard Executor.validLoggingLevels.contains(loggingLevel) else {
+            throw ValidationError("Please specify a valid logging level in the range: \(Executor.validLoggingLevels)")
+        }
+
+        srcDirs = self.sourceDirs.map(fullPath)
+
         // If source file list exists, source files value will be overriden (see the usage in setupArguments above)
-        if let srcList = arguments.get(sourceFileList) {
+        if let srcList = sourceFileList {
             let text = try? String(contentsOfFile: srcList, encoding: String.Encoding.utf8)
-            srcs = text?.components(separatedBy: "\n").filter{!$0.isEmpty}.map(fullPath)
+            srcs = text?.components(separatedBy: "\n").filter{!$0.isEmpty}.map(fullPath) ?? []
         } else {
-            srcs = arguments.get(sourceFiles)?.map(fullPath)
+            srcs = sourceFiles.map(fullPath)
         }
 
-        if srcDirs == nil, srcs == nil {
-            fatalError("Missing source files or directories")
+        if srcDirs.isEmpty && srcs.isEmpty {
+            throw ValidationError("Missing source files or directories")
         }
+    }
+
+    // Source paths to be used in `run`
+    private var srcDirs: [String] = []
+    private var srcs: [String] = []
+
+    mutating func run() throws {
+        print("Start...")
+        defer { print("Done.") }
+
+        let outputFilePath = fullPath(self.outputFilePath)
         
         var mockFilePaths: [String]?
         // First see if a list of mock files are stored in a file
-        if let mockList = arguments.get(self.mockFileList) {
+        if let mockList = self.mockFileList {
             let text = try? String(contentsOfFile: mockList, encoding: String.Encoding.utf8)
             mockFilePaths = text?.components(separatedBy: "\n").filter{!$0.isEmpty}.map(fullPath)
         } else {
             // If not, see if a list of mock files are directly passed in
-            mockFilePaths = arguments.get(self.mockFilePaths)?.map(fullPath)
+            mockFilePaths = self.mockFilePaths.map(fullPath)
         }
-        
-        let concurrencyLimit = arguments.get(self.concurrencyLimit)
-        let exclusionSuffixes = arguments.get(self.exclusionSuffixes) ?? []
-        let annotation = arguments.get(self.annotation) ?? String.mockAnnotation
-        let header = arguments.get(self.header)
-        let loggingLevel = arguments.get(self.loggingLevel) ?? 0
-        let macro = arguments.get(self.macro)
-        let testableImports = arguments.get(self.testableImports)
-        let customImports = arguments.get(self.customImports)
-        let excludeImports = arguments.get(self.excludeImports)
-        let shouldUseTemplateFunc = arguments.get(useTemplateFunc) ?? false
-        let shouldUseMockObservable = arguments.get(useMockObservable) ?? false
-        let shouldMockAll = arguments.get(mockAll) ?? false
-        let shouldCaptureAllFuncArgsHistory = arguments.get(enableArgsHistory) ?? false
-        let shouldMockFinal = arguments.get(mockFinal) ?? false
-        let allowSet = arguments.get(allowSetCallCount) ?? false
 
         do {
             try generate(sourceDirs: srcDirs,
@@ -212,12 +182,12 @@ class Executor {
                          annotation: annotation,
                          header: header,
                          macro: macro,
-                         declType: shouldMockAll ? .all : .protocolType,
-                         useTemplateFunc: shouldUseTemplateFunc,
-                         useMockObservable: shouldUseMockObservable,
-                         allowSetCallCount: allowSet,
-                         enableFuncArgsHistory: shouldCaptureAllFuncArgsHistory,
-                         mockFinal: shouldMockFinal,
+                         declType: mockAll ? .all : .protocolType,
+                         useTemplateFunc: useTemplateFunc,
+                         useMockObservable: useMockObservable,
+                         allowSetCallCount: allowSetCallCount,
+                         enableFuncArgsHistory: enableArgsHistory,
+                         mockFinal: mockFinal,
                          testableImports: testableImports,
                          customImports: customImports,
                          excludeImports: excludeImports,
@@ -226,7 +196,6 @@ class Executor {
                          concurrencyLimit: concurrencyLimit,
                          onCompletion: { _ in
                     log("Done. Exiting program.", level: .info)
-                    exit(0)
             })
         } catch {
             fatalError("Generation error: \(error)")

--- a/Sources/Mockolo/main.swift
+++ b/Sources/Mockolo/main.swift
@@ -13,6 +13,8 @@
 //  See the License for the specific language governing permissions and
 //  limitations under the License.
 //
+
+import ArgumentParser
 import Foundation
 import TSCUtility
 import TSCBasic

--- a/Sources/Mockolo/main.swift
+++ b/Sources/Mockolo/main.swift
@@ -19,27 +19,13 @@ import TSCBasic
 import MockoloFramework
 
 func main() {
-    let parser = ArgumentParser(usage: "<options>", overview: "Mockolo: Swift mock generator.")
     let inputs = Array(CommandLine.arguments.dropFirst())
     if let arg = inputs.first, (arg == "--version" || arg == "-v") {
         print(Version.current.value)
         return
     }
-    
-    let command = Executor(parser: parser)
 
-    print("Start...")
-    do {
-        /* Example:
-         .build/release/mockolo -srcs File1.swift File2.swift -out result/Mocks.swift -mocks FooMocks.swift -exclude "Mocks" "Tests"
-         */
-        let args = try parser.parse(inputs)
-        command.execute(with: args)
-    } catch {
-        fatalError("Command-line pasing error (use --help for help): \(error)")
-    }
-    
-    print("Done.")
+    Executor.main(inputs)
 }
 
 

--- a/Sources/MockoloFramework/Operations/Generator.swift
+++ b/Sources/MockoloFramework/Operations/Generator.swift
@@ -22,8 +22,8 @@ enum InputError: Error {
 }
 
 /// Performs end to end mock generation flow
-public func generate(sourceDirs: [String]?,
-                     sourceFiles: [String]?,
+public func generate(sourceDirs: [String],
+                     sourceFiles: [String],
                      parser: SourceParser,
                      exclusionSuffixes: [String],
                      mockFilePaths: [String]?,
@@ -36,14 +36,14 @@ public func generate(sourceDirs: [String]?,
                      allowSetCallCount: Bool,
                      enableFuncArgsHistory: Bool,
                      mockFinal: Bool,
-                     testableImports: [String]?,
-                     customImports: [String]?,
-                     excludeImports: [String]?,
+                     testableImports: [String],
+                     customImports: [String],
+                     excludeImports: [String],
                      to outputFilePath: String,
                      loggingLevel: Int,
                      concurrencyLimit: Int?,
                      onCompletion: @escaping (String) -> ()) throws {
-    guard sourceDirs != nil || sourceFiles != nil else {
+    guard sourceDirs.count > 0 || sourceFiles.count > 0 else {
         log("Source files or directories do not exist", level: .error)
         throw InputError.sourceFilesError
     }
@@ -80,8 +80,8 @@ public func generate(sourceDirs: [String]?,
     
     signpost_begin(name: "Generate protocol map")
     log("Process source files and generate an annotated/protocol map...", level: .info)
-    let paths = sourceDirs ?? sourceFiles
-    let isDirs = sourceDirs != nil
+    let paths = !sourceDirs.isEmpty ? sourceDirs : sourceFiles
+    let isDirs = !sourceDirs.isEmpty
     parser.parseDecls(paths,
                       isDirs: isDirs,
                       exclusionSuffixes: exclusionSuffixes,
@@ -161,56 +161,4 @@ public func generate(sourceDirs: [String]?,
     log("#Protocols = \(protocolMap.count), #Annotated protocols = \(annotatedProtocolMap.count), #Parent mock classes = \(parentMocks.count), #Final mock classes = \(candidates.count), File LoC = \(count)", level: .verbose)
     
     onCompletion(result)
-}
-
-
-
- class ModuleX {
-     typealias SomeType = String
-    static var x: String? = nil
-}
-@objc
- protocol NonSimpleVars {
-    @available(iOS 10.0, *)
-    var dict: Dictionary<String, Int> { get set }
-
-    var closureVar: ((_ arg: String) -> Void)? { get }
-    var voidHandler: (() -> ()) { get }
-    var hasDot: ModuleX.SomeType? { get }
-    static var someVal: String { get }
-}
-
-
-@available(iOS 10.0, *)
- class NonSimpleVarsMock: NonSimpleVars {
-     init() { }
-     init(dict: Dictionary<String, Int> = Dictionary<String, Int>(), voidHandler: @escaping (() -> ()), hasDot: ModuleX.SomeType? = nil) {
-        self.dict = dict
-        self._voidHandler = voidHandler
-        self.hasDot = hasDot
-    }
-
-
-     private(set) var dictSetCallCount = 0
-     var dict: Dictionary<String, Int> = Dictionary<String, Int>() { didSet { dictSetCallCount += 1 } }
-
-     private(set) var closureVarSetCallCount = 0
-     var closureVar: ((_ arg: String) -> Void)? = nil { didSet { closureVarSetCallCount += 1 } }
-
-     private(set) var voidHandlerSetCallCount = 0
-    private var _voidHandler: ((() -> ()))!  { didSet { voidHandlerSetCallCount += 1 } }
-     var voidHandler: (() -> ()) {
-        get { return _voidHandler }
-        set { _voidHandler = newValue }
-    }
-
-     private(set) var hasDotSetCallCount = 0
-     var hasDot: ModuleX.SomeType? = nil { didSet { hasDotSetCallCount += 1 } }
-
-     static private(set) var someValSetCallCount = 0
-    static private var _someVal: String = "" { didSet { someValSetCallCount += 1 } }
-     static var someVal: String {
-        get { return _someVal }
-        set { _someVal = newValue }
-    }
 }

--- a/Sources/MockoloFramework/Parsers/SourceParser.swift
+++ b/Sources/MockoloFramework/Parsers/SourceParser.swift
@@ -43,15 +43,15 @@ public class SourceParser {
     /// @param fileMacro: File level macro
     /// @param declType: The declaration type, e.g. protocol, class.
     /// @param completion:The block to be executed on completion
-    public func parseDecls(_ paths: [String]?,
+    public func parseDecls(_ paths: [String],
                            isDirs: Bool,
-                           exclusionSuffixes: [String]? = nil,
+                           exclusionSuffixes: [String],
                            annotation: String,
                            fileMacro: String?,
                            declType: DeclType,
                            completion: @escaping ([Entity], ImportMap?) -> ()) {
         
-        guard let paths = paths else { return }
+        guard !paths.isEmpty else { return }
         scan(paths, isDirectory: isDirs) { (path, lock) in
             self.generateASTs(path,
                               exclusionSuffixes: exclusionSuffixes,
@@ -64,7 +64,7 @@ public class SourceParser {
     }
 
     private func generateASTs(_ path: String,
-                              exclusionSuffixes: [String]? = nil,
+                              exclusionSuffixes: [String] = [],
                               annotation: String,
                               fileMacro: String?,
                               declType: DeclType,

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -192,12 +192,12 @@ extension StringProtocol {
         return prefix(1).capitalized + dropFirst()
     }
     
-    func shouldParse(with exclusionList: [String]? = nil) -> Bool {
+    func shouldParse(with exclusionList: [String]) -> Bool {
         guard hasSuffix(".swift") else { return false }
-        guard let exlist = exclusionList else { return true }
+        guard !exclusionList.isEmpty else { return true }
         
         if let name = components(separatedBy: ".swift").first {
-            for ex in exlist {
+            for ex in exclusionList {
                 if name.hasSuffix(ex) {
                     return false
                 }

--- a/Tests/MockoloTestCase.swift
+++ b/Tests/MockoloTestCase.swift
@@ -54,7 +54,7 @@ class MockoloTestCase: XCTestCase {
         }
     }
     
-    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String]? = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, concurrencyLimit: Int? = 1) {
+    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, concurrencyLimit: Int? = 1) {
         var mockList: [String]?
         if let mock = mockContent {
             if mockList == nil {
@@ -65,7 +65,7 @@ class MockoloTestCase: XCTestCase {
         verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, concurrencyLimit: concurrencyLimit)
     }
     
-    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: DeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String]?, allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, concurrencyLimit: Int?) {
+    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: DeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, concurrencyLimit: Int?) {
         var index = 0
         srcFilePathsCount = srcContents.count
         mockFilePathsCount = mockContents?.count ?? 0
@@ -106,7 +106,7 @@ class MockoloTestCase: XCTestCase {
         \(macroEnd)
         """
         
-        try? generate(sourceDirs: nil,
+        try? generate(sourceDirs: [],
                       sourceFiles: srcFilePaths,
                       parser: SourceParser(),
                       exclusionSuffixes: ["Mocks", "Tests"],
@@ -121,8 +121,8 @@ class MockoloTestCase: XCTestCase {
                       enableFuncArgsHistory: enableFuncArgsHistory,
                       mockFinal: mockFinal,
                       testableImports: testableImports,
-                      customImports: nil,
-                      excludeImports: nil,
+                      customImports: [],
+                      excludeImports: [],
                       to: dstFilePath,
                       loggingLevel: 3,
                       concurrencyLimit: concurrencyLimit,


### PR DESCRIPTION
Resolves #148 

- Replace swift-tools-support-core deprecated ArgumentParser with swift-argument-parser
- Give loggingLevel and annotation default levels via ArgumentParser
- Move some validation logic to Executor.validate
- Make destination a required option
- Add validation for logging levels

I am unsure about unit testing these changes. I think stubbed functions for `generate` and `fullPath` would need to be injected into `Executor`, but those break synthesized Decodable conformance which is a require for implementers of `ParsableCommand`..