### PR TITLE
Update SwiftSyntax and support Swift 5.4.2 and 5.5 in CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: [12.5.1, 13.0]
+        xcode: ["12.5.1", "13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -7,19 +7,21 @@ on:
     branches: [master]
 
 jobs:
-  build-macos:
+  run:
     runs-on: macos-11
+    strategy:
+      matrix:
+        xcode: [12.5.1, 13.0]
     steps:
       - name: Checkout
         uses: actions/checkout@v2
+      - name: Set Xcode ${{ matrix.xcode }}
+        run: |
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+          xcodebuild -version
+          swift --version
+          swift package --version
       - name: Build
         run: swift build -v
-
-  test-macos:
-    runs-on: macos-11
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v2
       - name: Test
         run: swift test -v -c release
-

--- a/Package.swift
+++ b/Package.swift
@@ -8,7 +8,7 @@ var dependencies: [Package.Dependency] = [
 
 let swiftSyntax: Package.Dependency
 #if swift(>=5.5)
-swiftSyntax = .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("release/5.5"))
+swiftSyntax = .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0"))
 #else
 swiftSyntax = .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0"))
 #endif


### PR DESCRIPTION
## Overview

- Update SwiftSyntax
- Support Swift 5.4.2 and 5.5 in CI

## References

- https://github.com/apple/swift-syntax/releases/tag/0.50500.0
- https://docs.github.com/en/actions/reference/workflow-syntax-for-github-actions#jobsjob_idstrategymatrix
- https://github.com/yonaskolb/XcodeGen/blob/12511afed82a3db1a9dbd814e835920c98d9914e/.github/workflows/ci.yml