### PR TITLE
update SwiftArgumentParser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
-    .package(url: "https://github.com/apple/swift-argument-parser", .exact("0.4.3")),
+    .package(url: "https://github.com/apple/swift-argument-parser", .exact("1.0.1")),
 ]
 
 let swiftSyntax: Package.Dependency


### PR DESCRIPTION
## Overview

* Update SwiftArgumentParser
* Make it possible to use with swift-format

## Motivation

When used with swift-format `v0.50500.0` , there is a problem with swift package resolve not being able to resolve dependencies

```
error: Dependencies could not be resolved because root depends on 'swift-format' 0.50500.0 and root depends on 'mockolo' 1.6.0.
'mockolo' is incompatible with 'swift-format' because 'mockolo' 1.6.0 depends on 'swift-argument-parser' 0.4.3 and 'swift-format' >= 0.50500.0 depends on 'swift-argument-parser' 1.0.1..<1.1.0.
```

When using mockolo `v1.6.0` without upgrading to swift-format `v0.50500.0` , the following error occurred and SwiftSyntax was not dependent on it

```
Start...
["Process input mock files..."]
["Took", 0.00010597705841064453]
["Process source files and generate an annotated/protocol map..."]
MockoloFramework/SourceParser.swift:101: Fatal error: The operation couldn’t be completed. (SwiftSyntax.ParserError error 1.)
```