### PR TITLE
Fix Swift Argument Parser

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
-    .package(url: "https://github.com/apple/swift-argument-parser", .exact("1.0.1")),
+    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
 ]
 
 let swiftSyntax: Package.Dependency


### PR DESCRIPTION
## Overview

Replace `exact` with `from`.

ref: https://github.com/apple/swift-package-manager/blob/ce50cb0de101c2d9a5742aaf70efc7c21e8f249b/Documentation/PackageDescription.md#methods-4

> /// Specifying exact version requirements are not recommended as
> /// they can cause conflicts in your dependency graph when multiple other packages depend on a package.
> /// As Swift packages follow the semantic versioning convention,
> /// think about specifying a version range instead.