### PR TITLE
Fix warnings of unhandled files in MockoloFramework

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -36,6 +36,10 @@ let package = Package(
             name: "MockoloFramework",
             dependencies: [
                 .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+            ],
+            exclude: [
+                "README.md",
+                "LICENSE.txt",
             ]
         ),
         .testTarget(


### PR DESCRIPTION
Occur warnings when opening this project by Xcode or building.
These files are unneeded for build so exclude in Package.swift.

```
found 2 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
/Sources/MockoloFramework/README.txt
/Sources/MockoloFramework/LICENSE.txt
```

## Environment

- Xcode 13.2.1 (13C100)
