### PR TITLE
Support Swift 5.6

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: ["12.5.1", "13.0"]
+        xcode: ["12.5.1", "13.0", "13.3"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: macos-11
     strategy:
       matrix:
-        xcode: ["12.5.1", "13.0", "13.3"]
+        xcode: ["12.5.1", "13.0"]
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/Package.swift
+++ b/Package.swift
@@ -5,14 +5,18 @@ var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
     .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
 ]
+var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
+    .product(name: "SwiftSyntax", package: "SwiftSyntax"),
+]
 
-let swiftSyntax: Package.Dependency
-#if swift(>=5.5)
-swiftSyntax = .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0"))
+#if swift(>=5.6)
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("release/5.6")))
+mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
+#elseif swift(>=5.5)
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")))
 #else
-swiftSyntax = .package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0"))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50400.0")))
 #endif
-dependencies.append(swiftSyntax)
 
 let package = Package(
     name: "Mockolo",
@@ -34,9 +38,7 @@ let package = Package(
                 ]),
         .target(
             name: "MockoloFramework",
-            dependencies: [
-                .product(name: "SwiftSyntax", package: "SwiftSyntax"),
-            ],
+            dependencies: mockoloFrameworkTargetDependencies,
             exclude: [
                 "README.md",
                 "LICENSE.txt",

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
 ]
 
 #if swift(>=5.6)
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("release/5.6")))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.0")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.5)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")))

--- a/Package.swift
+++ b/Package.swift
@@ -3,7 +3,7 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
-    .package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"),
+    .package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"),
 ]
 var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
     .product(name: "SwiftSyntax", package: "SwiftSyntax"),

--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
 ]
 
 #if swift(>=5.6)
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.0")))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("release/5.6")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.5)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")))

--- a/Sources/MockoloFramework/Parsers/SourceParser.swift
+++ b/Sources/MockoloFramework/Parsers/SourceParser.swift
@@ -16,7 +16,9 @@
 
 import Foundation
 import SwiftSyntax
-
+#if canImport(SwiftSyntaxParser)
+import SwiftSyntaxParser
+#endif
 
 public enum DeclType {
     case protocolType, classType, other, all

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -7,16 +7,17 @@
 
 import Foundation
 import SwiftSyntax
+#if canImport(SwiftSyntaxParser)
+import SwiftSyntaxParser
+#endif
 
 extension SyntaxParser {
-    public static func parse(_ fileData: Data, path: String,
-                             diagnosticEngine: DiagnosticEngine? = nil) throws -> SourceFileSyntax {
+    public static func parse(_ fileData: Data, path: String) throws -> SourceFileSyntax {
         // Avoid using `String(contentsOf:)` because it creates a wrapped NSString.
         let source = fileData.withUnsafeBytes { buf in
             return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
         }
-        return try parse(source: source, filenameForDiagnostics: path,
-                         diagnosticEngine: diagnosticEngine)
+        return try parse(source: source, filenameForDiagnostics: path)
     }
 
     public static func parse(_ path: String) throws -> SourceFileSyntax {


### PR DESCRIPTION
# Overview
 - Added Swift 5.6 support to solve the problem of failing to generate mocks in Xcode 13.3
# Notes
 - I have not added CI execution in Swift 5.6 because GitHub-hosted runners in github actions does not currently support macOS 12