### PR TITLE
Bump SwiftSyntax to exact 0.50600.1 in Swift 5.6

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
 ]
 
 #if swift(>=5.6)
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .branch("release/5.6")))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.5)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50500.0")))


### PR DESCRIPTION
SwiftSyntax has released to resolve https://bugs.swift.org/browse/SR-15989, so I specified to `.exact("0.50600.1")`.

related: https://github.com/uber/mockolo/pull/178 fyi @aroshipup 