### PR TITLE
Handle varying names for SyntaxParser

### DIFF
--- a/Sources/MockoloFramework/Parsers/SourceParser.swift
+++ b/Sources/MockoloFramework/Parsers/SourceParser.swift
@@ -15,7 +15,9 @@
 //
 
 import Foundation
+#if canImport(SwiftSyntax)
 import SwiftSyntax
+#endif
 #if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
 #endif
@@ -52,7 +54,7 @@ public class SourceParser {
                            fileMacro: String?,
                            declType: DeclType,
                            completion: @escaping ([Entity], ImportMap?) -> ()) {
-        
+
         guard !paths.isEmpty else { return }
         scan(paths, isDirectory: isDirs) { (path, lock) in
             self.generateASTs(path,
@@ -72,7 +74,7 @@ public class SourceParser {
                               declType: DeclType,
                               lock: NSLock?,
                               completion: @escaping ([Entity], ImportMap?) -> ()) {
-        
+
         guard path.shouldParse(with: exclusionSuffixes) else { return }
 
         if !annotation.isEmpty {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -6,7 +6,9 @@
 //
 
 import Foundation
+#if canImport(SwiftSyntax)
 import SwiftSyntax
+#endif
 #if canImport(SwiftSyntaxParser)
 import SwiftSyntaxParser
 #endif


### PR DESCRIPTION
These names have changed over time,
therefore we must allow for either
name to be imported