### PR TITLE
Update CI

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   run:
+    name: Build and test with Xcode ${{ matrix.xcode.version }} on ${{ matrix.xcode.os }}
     runs-on: ${{ matrix.xcode.os }}
     strategy:
       matrix:
@@ -18,7 +19,7 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode ${{ matrix.xcode.os }}
+      - name: Set Xcode ${{ matrix.xcode.version }}
         run: |
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode.version }}.app
           xcodebuild -version

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -17,7 +17,7 @@ jobs:
           - { os: macos-12, version: "13.3.1" }
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
       - name: Set Xcode ${{ matrix.xcode.os }}
         run: |
           sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode.version }}.app

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -19,9 +19,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Set Xcode ${{ matrix.xcode.version }}
+      - name: Show versions
         run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode.version }}.app
           xcodebuild -version
           swift --version
           swift package --version
@@ -29,3 +28,5 @@ jobs:
         run: swift build -v
       - name: Test
         run: swift test -v -c release
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_${{ matrix.xcode.version }}.app

--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -8,16 +8,19 @@ on:
 
 jobs:
   run:
-    runs-on: macos-11
+    runs-on: ${{ matrix.xcode.os }}
     strategy:
       matrix:
-        xcode: ["12.5.1", "13.0"]
+        xcode:
+          - { os: macos-11, version: "12.5.1" }
+          - { os: macos-11, version: "13.0" }
+          - { os: macos-12, version: "13.3.1" }
     steps:
       - name: Checkout
         uses: actions/checkout@v2
-      - name: Set Xcode ${{ matrix.xcode }}
+      - name: Set Xcode ${{ matrix.xcode.os }}
         run: |
-          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode }}.app
+          sudo xcode-select -s /Applications/Xcode_${{ matrix.xcode.version }}.app
           xcodebuild -version
           swift --version
           swift package --version


### PR DESCRIPTION
## Details

- Run CI with Xcode 13.3.1
- Bump actions/checkout from v2 to v3
- Set `DEVELOPER_DIR`

## Reference

- https://github.com/IBDecodable/IBDecodable/blob/d36937a8ba23252d2ffab48472605935c9c65477/.github/workflows/swift.yml