### PR TITLE
Use @main in Mockolo target

### DIFF
--- a/Sources/Mockolo/Mockolo.swift
+++ b/Sources/Mockolo/Mockolo.swift
@@ -20,15 +20,15 @@ import TSCUtility
 import TSCBasic
 import MockoloFramework
 
-func main() {
-    let inputs = Array(CommandLine.arguments.dropFirst())
-    if let arg = inputs.first, (arg == "--version" || arg == "-v") {
-        print(Version.current.value)
-        return
+@main
+struct Mockolo {
+    static func main() {
+        let inputs = Array(CommandLine.arguments.dropFirst())
+        if let arg = inputs.first, (arg == "--version" || arg == "-v") {
+            print(Version.current.value)
+            return
+        }
+
+        Executor.main(inputs)
     }
-
-    Executor.main(inputs)
 }
-
-
-main()


### PR DESCRIPTION
Mockolo support Swift 5.4+, so `@main` can be used
- https://github.com/uber/mockolo/commit/092191872fa3dbdcd0b126dde49fc9eff6c19f35

# Related

- https://github.com/uber/mockolo/pull/143
- https://github.com/apple/swift-evolution/blob/main/proposals/0294-package-executable-targets.md
