### PR TITLE
Report error when fails to write mock file

### DIFF
--- a/Sources/MockoloFramework/Operations/Generator.swift
+++ b/Sources/MockoloFramework/Operations/Generator.swift
@@ -150,7 +150,7 @@ public func generate(sourceDirs: [String],
                                 excludeImports: excludeImports,
                                 testableImports: testableImports)
 
-    let result = write(candidates: candidates,
+    let result = try write(candidates: candidates,
                        header: header,
                        macro: macro,
                        imports: imports,

--- a/Sources/MockoloFramework/Operations/OutputWriter.swift
+++ b/Sources/MockoloFramework/Operations/OutputWriter.swift
@@ -21,7 +21,7 @@ func write(candidates: [(String, Int64)],
            header: String?,
            macro: String?,
            imports: String,
-           to outputFilePath: String) -> String {
+           to outputFilePath: String) throws -> String {
 
     let entities = candidates
         .sorted { (left: (String, Int64), right: (String, Int64)) -> Bool in
@@ -46,7 +46,7 @@ func write(candidates: [(String, Int64)],
         return ret
     }
 
-    _ = try? ret.write(toFile: outputFilePath, atomically: true, encoding: .utf8)
+    _ = try ret.write(toFile: outputFilePath, atomically: true, encoding: .utf8)
     return ret
 }
 

--- a/Tests/MockoloTestCase.swift
+++ b/Tests/MockoloTestCase.swift
@@ -7,7 +7,7 @@ class MockoloTestCase: XCTestCase {
 
     let bundle = Bundle(for: MockoloTestCase.self)
 
-    lazy var dstFilePath: String = {
+    lazy var defaultDstFilePath: String = {
         return bundle.bundlePath + "/Dst.swift"
     }()
 
@@ -39,13 +39,13 @@ class MockoloTestCase: XCTestCase {
 
     override func setUp() {
         // Put setup code here. This method is called before the invocation of each test method in the class.
-        let created = FileManager.default.createFile(atPath: dstFilePath, contents: nil, attributes: nil)
+        let created = FileManager.default.createFile(atPath: defaultDstFilePath, contents: nil, attributes: nil)
         XCTAssert(created)
     }
 
     override func tearDown() {
         // Put teardown code here. This method is called after the invocation of each test method in the class.
-        try? FileManager.default.removeItem(atPath: dstFilePath)
+        try? FileManager.default.removeItem(atPath: defaultDstFilePath)
         for srcpath in srcFilePaths {
             try? FileManager.default.removeItem(atPath: srcpath)
         }
@@ -54,8 +54,8 @@ class MockoloTestCase: XCTestCase {
         }
     }
 
-    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, outputFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false) {
-        let outputFilePath = outputFilePath ?? dstFilePath
+    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false) {
+        let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
             if mockList == nil {
@@ -63,11 +63,11 @@ class MockoloTestCase: XCTestCase {
             }
             mockList?.append(mock)
         }
-        try? verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, outputFilePath: outputFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues)
+        try? verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues)
     }
     
-    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, outputFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }) {
-        let outputFilePath = outputFilePath ?? dstFilePath
+    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }) {
+        let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
             if mockList == nil {
@@ -76,13 +76,13 @@ class MockoloTestCase: XCTestCase {
             mockList?.append(mock)
         }
         XCTAssertThrowsError(
-            try verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, outputFilePath: outputFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues),
+            try verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues),
             "No error was thrown",
             errorHandler
         )
     }
 
-    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: DeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, outputFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool) throws {
+    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: DeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, dstFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool) throws {
         var index = 0
         srcFilePathsCount = srcContents.count
         mockFilePathsCount = mockContents?.count ?? 0
@@ -141,11 +141,11 @@ class MockoloTestCase: XCTestCase {
                       testableImports: testableImports,
                       customImports: [],
                       excludeImports: [],
-                      to: outputFilePath,
+                      to: dstFilePath,
                       loggingLevel: 3,
                       concurrencyLimit: concurrencyLimit,
             onCompletion: { ret in
-                let output = (try? String(contentsOf: URL(fileURLWithPath: self.dstFilePath), encoding: .utf8)) ?? ""
+                let output = (try? String(contentsOf: URL(fileURLWithPath: self.defaultDstFilePath), encoding: .utf8)) ?? ""
                 let outputContents = output.components(separatedBy:  .whitespacesAndNewlines).filter{!$0.isEmpty}
                 let fixtureContents = formattedDstContent.components(separatedBy: .whitespacesAndNewlines).filter{!$0.isEmpty}
                 #if TEST

--- a/Tests/TestOutputChange/OutputChangeTests.swift
+++ b/Tests/TestOutputChange/OutputChangeTests.swift
@@ -6,14 +6,14 @@ class OutputChangeTests: MockoloTestCase {
         verify(srcContent: simpleFuncs,
                dstContent: simpleFuncsMock)
 
-        let expectedAttributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let expectedAttributes = try FileManager.default.attributesOfItem(atPath: defaultDstFilePath)
         let expectedCreationDate = (expectedAttributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
         let expectedModificationDate = (expectedAttributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
 
         verify(srcContent: simpleFuncs,
                dstContent: simpleFuncsMock)
 
-        let attributes = try FileManager.default.attributesOfItem(atPath: dstFilePath)
+        let attributes = try FileManager.default.attributesOfItem(atPath: defaultDstFilePath)
         let creationDate = (attributes[.creationDate] as! Date).timeIntervalSinceReferenceDate
         let modificationDate = (attributes[.modificationDate] as! Date).timeIntervalSinceReferenceDate
 

--- a/Tests/TestThrowingErrors/ThrowingErrorsTests.swift
+++ b/Tests/TestThrowingErrors/ThrowingErrorsTests.swift
@@ -1,0 +1,17 @@
+import Foundation
+import XCTest
+
+class ThrowingErrorsTests: MockoloTestCase {
+    func testNonexistentDestinationDirectoryError() {
+        let nonExistentOutputDirPath = "/nonexistent/directory"
+        
+        XCTAssertFalse(
+            FileManager.default.fileExists(atPath: nonExistentOutputDirPath),
+            "\(nonExistentOutputDirPath) is expected not to exist, but it exists"
+        )
+        
+        verifyThrows(srcContent: simpleFuncs,
+                     dstContent: simpleFuncsMock,
+                     outputFilePath: nonExistentOutputDirPath + "/Dst.swift")
+    }
+}

--- a/Tests/TestThrowingErrors/ThrowingErrorsTests.swift
+++ b/Tests/TestThrowingErrors/ThrowingErrorsTests.swift
@@ -3,15 +3,15 @@ import XCTest
 
 class ThrowingErrorsTests: MockoloTestCase {
     func testNonexistentDestinationDirectoryError() {
-        let nonExistentOutputDirPath = "/nonexistent/directory"
+        let nonExistentDstDirPath = "/nonexistent/directory"
         
         XCTAssertFalse(
-            FileManager.default.fileExists(atPath: nonExistentOutputDirPath),
-            "\(nonExistentOutputDirPath) is expected not to exist, but it exists"
+            FileManager.default.fileExists(atPath: nonExistentDstDirPath),
+            "\(nonExistentDstDirPath) is expected not to exist, but it exists"
         )
         
         verifyThrows(srcContent: simpleFuncs,
                      dstContent: simpleFuncsMock,
-                     outputFilePath: nonExistentOutputDirPath + "/Dst.swift")
+                     dstFilePath: nonExistentDstDirPath + "/Dst.swift")
     }
 }


### PR DESCRIPTION
Close #189 

This PR makes mockolo command report error in log message and finish with non-zero exit code when it fails to create mock file. Change of the log message for that situation is shown below.

### before

```
❯ mockolo --sourcedirs Path/To/SourceDir --destination /NonexistentDirectory/Mocks.swift
Start...
["Process input mock files..."]
["Took", 4.1961669921875e-05]
["Process source files and generate an annotated/protocol map..."]
["Took", 0.023231029510498047]
["Resolve inheritance and generate unique entity models..."]
["Took", 0.0008450746536254883]
["Render models with templates..."]
["Took", 0.0002319812774658203]
["Write the mock results and import lines to", "/NonexistentDirectory/Mocks.swift"]
["Took", 0.0001609325408935547]
["TOTAL", 0.024510979652404785]
["#Protocols = 3, #Annotated protocols = 3, #Parent mock classes = 0, #Final mock classes = 3, File LoC = 77"]
["Done. Exiting program."]
Done.
```

## after

```
❯ mockolo --sourcedirs Path/To/SourceDir --destination /NonexistentDirectory/Mocks.swift
Start...
["Process input mock files..."]
["Took", 6.496906280517578e-05]
["Process source files and generate an annotated/protocol map..."]
["Took", 0.07189595699310303]
["Resolve inheritance and generate unique entity models..."]
["Took", 7.808208465576172e-05]
["Render models with templates..."]
["Took", 9.894371032714844e-06]
["Write the mock results and import lines to", "/NonexistentDirectory/Mocks.swift"]
Mockolo/Executor.swift:213: Fatal error: Generation error: Error Domain=NSCocoaErrorDomain Code=4 "The folder “Mocks.swift” doesn’t exist." UserInfo={NSFilePath=/NonexistentDirectory/Mocks.swift, NSUserStringVariant=Folder, NSUnderlyingError=0x600003ce90e0 {Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"}}
zsh: trace trap  .build/arm64-apple-macosx/debug/mockolo --sourcedirs Sources --destination
```

