### PR TITLE
Add customImports command shorthand back

### DIFF
--- a/Sources/Mockolo/Executor.swift
+++ b/Sources/Mockolo/Executor.swift
@@ -38,7 +38,8 @@ struct Executor: ParsableCommand {
                 valueName: "n"))
     private var concurrencyLimit: Int?
 
-    @Option(parsing: .upToNextOption,
+    @Option(name: [.customShort("c"), .long],
+            parsing: .upToNextOption,
             help: "If set, custom module imports (separated by a space) will be added to the final import statement list.")
     private var customImports: [String] = []
 


### PR DESCRIPTION
Mockolo command line argument for customImports changed where -c shorthand was removed.

Previously, you could use either --custom-imports OR -c:
https://github.com/uber/mockolo/blob/d5f08f5e03bfc25f88adbe5bcab684ad2f25b45c/Sources/Mockolo/Executor.swift#L113-L114

But now only --custom-imports:
https://github.com/uber/mockolo/blob/master/Sources/Mockolo/Executor.swift#L41-L43

This occurred on https://github.com/uber/mockolo/pull/153 but there is no explicit mention of this change so hoping we can add it back so folks do not need to update their existing cli scripts.