### PR TITLE
Update swift-argument-parser dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,16 @@ import PackageDescription
 
 var dependencies: [Package.Dependency] = [
     .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.7")),
-    .package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"),
 ]
 var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
     .product(name: "SwiftSyntax", package: "SwiftSyntax"),
 ]
+
+#if swift(>=5.6)
+dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.1")))
+#else
+dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"))
+#endif
 
 #if swift(>=5.6)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")))

--- a/Package.swift
+++ b/Package.swift
@@ -9,7 +9,7 @@ var mockoloFrameworkTargetDependencies: [Target.Dependency] = [
 ]
 
 #if swift(>=5.6)
-dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", .upToNextMajor(from: "1.0.1")))
+dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", from: "1.0.1"))
 #else
 dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"))
 #endif


### PR DESCRIPTION
# Overview

* #178 added Swift 5.6 support, but f38ae33 limited the version flexibility of the swift-argument-parser dependency. The reasoning for this is explained in [this comment](https://github.com/uber/mockolo/pull/178#issuecomment-1071918213).
* This makes package resolution for other packages that have Mockolo as a dependency less flexible. So, to have the same flexibility as before f38ae33, but still account for the issue mentioned in the comment linked above, the version range of the  swift-argument-parser dependency is being made dependent on the Swift version.