### PR TITLE
Updated swift-tools-support-core version from 0.2.3 to 0.2.7

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -2,7 +2,7 @@
 import PackageDescription
 
 var dependencies: [Package.Dependency] = [
-    .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.3")),
+    .package(url: "https://github.com/apple/swift-tools-support-core.git", .exact("0.2.7")),
     .package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"),
 ]
 var mockoloFrameworkTargetDependencies: [Target.Dependency] = [


### PR DESCRIPTION
## Changes
I updated package [swift-tools-support-core](https://github.com/apple/swift-tools-support-core) from 0.2.3 to 0.2.7 because I can't build mockolo with Xcode 14 beta 5 with swift-tools-support-core 0.2.3. 

The origin of compiling error is [here](https://github.com/apple/swift-tools-support-core/blob/main/Sources/TSCUtility/FSWatch.swift#L848) and I attached the error.

<img width="1440" alt="スクリーンショット 2022-08-18 20 31 50" src="https://user-images.githubusercontent.com/44002126/185388737-e3ee55be-5afa-4d40-96da-a7a0f6265c8d.png">

This issue is fixed  in https://github.com/apple/swift-tools-support-core/pull/345 . which is included in version 0.2.7.
That's why I updated swift-tools-support-core version in mockolo from 0.2.3 to 0.2.7.

----
This issue was clarified thanks to @sidepelican and @omochi :pray:
