### PR TITLE
Make universal binary

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,11 +5,11 @@ on:
     types: [published]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_12.5.1.app
+  DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
 
 jobs:
   build-release:
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v3
     - name: Create the binary
@@ -22,7 +22,7 @@ jobs:
 
   deploy-binary:
     needs: build-release
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
     - uses: actions/download-artifact@v3
       with:

--- a/install-script.sh
+++ b/install-script.sh
@@ -64,9 +64,9 @@ echo "OUTPUT FILE = ${OUTFILE}"
 
 cd "$SRCDIR"
 rm -rf .build
-swift build -c release 
+swift build -c release --arch arm64 --arch x86_64
 
-cd .build/release
+cd .build/apple/Products/Release
 
 echo "** Install..."
 cp "$(xcode-select -p)"/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/lib_InternalSwiftSyntaxParser.dylib . 


### PR DESCRIPTION
https://github.com/uber/mockolo/releases/download/1.7.0/mockolo.tar.gz only includes arm64 architecture:

```
$ file mockolo
mockolo: Mach-O 64-bit executable arm64
```

The prebuilt binary should have both x86_64 and arm64 architecutres.