### PR TITLE
Fixes brew command in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ $ mint run uber/mockolo mockolo -h // see commandline input options below
 Option 2: [Homebrew](https://brew.sh/)
 
 ```
-$ brew install mockolo
+$ brew reinstall --build-from-source mockolo
 ```
 
 Option 3: Use the binary


### PR DESCRIPTION
Update README to use brew command that avoids the error in [issue 182](https://github.com/uber/mockolo/issues/182).