### PR TITLE
Bump swift-syntax for Swift 5.7

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -15,7 +15,8 @@ jobs:
         xcode:
           - { os: macos-11, version: "12.5.1" }
           - { os: macos-11, version: "13.0" }
-          - { os: macos-12, version: "13.3.1" }
+          - { os: macos-12, version: "13.4.1" }
+          - { os: macos-12, version: "14.0" }
     steps:
       - name: Checkout
         uses: actions/checkout@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     types: [published]
 
 env:
-  DEVELOPER_DIR: /Applications/Xcode_13.4.1.app
+  DEVELOPER_DIR: /Applications/Xcode_14.0.app
 
 jobs:
   build-release:

--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,10 @@ dependencies.append(.package(url: "https://github.com/apple/swift-argument-parse
 dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"))
 #endif
 
-#if swift(>=5.6)
+#if swift(>=5.7)
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.0")))
+mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
+#elseif swift(>=5.6)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.5)

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ dependencies.append(.package(url: "https://github.com/apple/swift-argument-parse
 #endif
 
 #if swift(>=5.7)
-dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.0")))
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.1")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.6)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50600.1")))


### PR DESCRIPTION
## References

- https://github.com/apple/swift-syntax/releases/tag/0.50700.0
- https://github.com/apple/swift-syntax/releases/tag/0.50700.1