### PR TITLE
Support type composition (`&` keyword)

### DIFF
--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -99,19 +99,24 @@ extension TypeInheritanceClauseSyntax {
     var types: [String] {
         var list = [String]()
         for element in self.inheritedTypeCollection {
-            if let composition = element.typeName.as(CompositionTypeSyntax.self) {
-                // Match Case: use `&` keyword to conform to multiple protocols.
-                // example: `A: B & C`
-                for compositionElement in composition.elements {
-                    if let elementName = compositionElement.firstToken?.text {
-                        list.append(elementName)
-                    }
-                }
-            } else if let elementName = element.firstToken?.text {
-                list.append(elementName)
-            }
+            let elementNameList = parseElementType(type: element.typeName)
+            list.append(contentsOf: elementNameList)
         }
         return list
+    }
+
+    private func parseElementType(type: TypeSyntax) -> [String] {
+        if let simpleTypeIdentifier = type.as(SimpleTypeIdentifierSyntax.self) {
+            // example: `protocol A: B {}`
+            return [simpleTypeIdentifier.name.text]
+        } else if let tupleType = type.as(TupleTypeSyntax.self) {
+            // example: `protocol A: (B) {}`
+            return tupleType.elements.map(\.type).map(parseElementType(type:)).flatMap { $0 }
+        } else if let compositionType = type.as(CompositionTypeSyntax.self) {
+            // example: `protocol A: B & C {}`
+            return compositionType.elements.map(\.type).map(parseElementType(type:)).flatMap { $0 }
+        }
+        return []
     }
 
     var typesDescription: String {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -99,7 +99,15 @@ extension TypeInheritanceClauseSyntax {
     var types: [String] {
         var list = [String]()
         for element in self.inheritedTypeCollection {
-            if let elementName = element.firstToken?.text {
+            if let composition = element.typeName.as(CompositionTypeSyntax.self) {
+                // Match Case: use `&` keyword to conform to multiple protocols.
+                // example: `A: B & C`
+                for compositionElement in composition.elements {
+                    if let elementName = compositionElement.firstToken?.text {
+                        list.append(elementName)
+                    }
+                }
+            } else if let elementName = element.firstToken?.text {
                 list.append(elementName)
             }
         }

--- a/Tests/TestOverloads/FixtureInheritance.swift
+++ b/Tests/TestOverloads/FixtureInheritance.swift
@@ -1,5 +1,6 @@
 import MockoloFramework
 
+// MARK: Simple inheritance
 let simpleInheritance = """
 import Foundation
 
@@ -8,13 +9,13 @@ public protocol SimpleChild: SimpleParent {
     var name: String { get set }
     func foo()
 }
-    
+
 /// \(String.mockAnnotation)
 public protocol SimpleParent: AnyObject {
     var number: Int { get set }
     func bar(arg: Double) -> Float?
 }
-    
+
 """
     
 let simpleInheritanceMock = """
@@ -74,6 +75,76 @@ public class SimpleParentMock: SimpleParent {
             return barHandler(arg)
         }
         return nil
+    }
+}
+
+"""
+
+// MARK: Multiple inheritance
+let twoTypeInheritance = """
+
+protocol FirstSwiftProtocol {
+    var someBool: Bool { get }
+
+    func doSomething()
+}
+
+protocol SecondSwiftProtocol {
+    var someInt: Int { get set }
+
+    func doSomethingElse() -> Bool
+}
+
+/// \(String.mockAnnotation)
+protocol TestProtocol: FirstSwiftProtocol & SecondSwiftProtocol {
+    func doSomethingSpecial()
+}
+
+"""
+
+let twoTypeInheritanceMock = """
+class TestProtocolMock: TestProtocol {
+    init() { }
+    init(someBool: Bool = false, someInt: Int = 0) {
+        self.someBool = someBool
+        self.someInt = someInt
+    }
+
+
+    private(set) var someBoolSetCallCount = 0
+    var someBool: Bool = false { didSet { someBoolSetCallCount += 1 } }
+
+    private(set) var doSomethingCallCount = 0
+    var doSomethingHandler: (() -> ())?
+    func doSomething()  {
+        doSomethingCallCount += 1
+        if let doSomethingHandler = doSomethingHandler {
+            doSomethingHandler()
+        }
+
+    }
+
+    private(set) var someIntSetCallCount = 0
+    var someInt: Int = 0 { didSet { someIntSetCallCount += 1 } }
+
+    private(set) var doSomethingElseCallCount = 0
+    var doSomethingElseHandler: (() -> (Bool))?
+    func doSomethingElse() -> Bool {
+        doSomethingElseCallCount += 1
+        if let doSomethingElseHandler = doSomethingElseHandler {
+            return doSomethingElseHandler()
+        }
+        return false
+    }
+
+    private(set) var doSomethingSpecialCallCount = 0
+    var doSomethingSpecialHandler: (() -> ())?
+    func doSomethingSpecial()  {
+        doSomethingSpecialCallCount += 1
+        if let doSomethingSpecialHandler = doSomethingSpecialHandler {
+            doSomethingSpecialHandler()
+        }
+
     }
 }
 

--- a/Tests/TestOverloads/FixtureInheritance.swift
+++ b/Tests/TestOverloads/FixtureInheritance.swift
@@ -80,8 +80,8 @@ public class SimpleParentMock: SimpleParent {
 
 """
 
-// MARK: Multiple inheritance
-let twoTypeInheritance = """
+// MARK: Composition inheritance
+let compositionInheritance = """
 
 protocol FirstSwiftProtocol {
     var someBool: Bool { get }
@@ -102,7 +102,7 @@ protocol TestProtocol: FirstSwiftProtocol & SecondSwiftProtocol {
 
 """
 
-let twoTypeInheritanceMock = """
+let compositionInheritanceMock = """
 class TestProtocolMock: TestProtocol {
     init() { }
     init(someBool: Bool = false, someInt: Int = 0) {

--- a/Tests/TestOverloads/OverloadTests.swift
+++ b/Tests/TestOverloads/OverloadTests.swift
@@ -74,5 +74,12 @@ class OverloadTests: MockoloTestCase {
         verify(srcContent: overload11,
                dstContent: overloadMock11)
     }
+
+    func testTwoInheritance() {
+        verify(
+            srcContent: twoTypeInheritance,
+            dstContent: twoTypeInheritanceMock
+        )
+    }
     
 }

--- a/Tests/TestOverloads/OverloadTests.swift
+++ b/Tests/TestOverloads/OverloadTests.swift
@@ -77,8 +77,8 @@ class OverloadTests: MockoloTestCase {
 
     func testTwoInheritance() {
         verify(
-            srcContent: twoTypeInheritance,
-            dstContent: twoTypeInheritanceMock
+            srcContent: compositionInheritance,
+            dstContent: compositionInheritanceMock
         )
     }
     


### PR DESCRIPTION
## Overview
When use `&` keyword to conform to multiple protocols, mockolo only picks up the first protocol.

This issue is already mentioned in #170 

- target mockable

```swift
protocol FirstSwiftProtocol {
    var someBool: Bool { get }

    func doSomething()
}

protocol SecondSwiftProtocol {
    var someInt: Int { get set }

    func doSomethingElse() -> Bool
}

/// @mockable
protocol TestProtocol: FirstSwiftProtocol & SecondSwiftProtocol {
    func doSomethingSpecial()
}

```

- Output mock (members in `SecondSwiftProtocol` are not implemented.)

```swift
///
/// @Generated by Mockolo
///






class TestProtocolMock: TestProtocol {
    init() { }
    init(someBool: Bool = false) {
        self.someBool = someBool
    }


    private(set) var someBoolSetCallCount = 0
    var someBool: Bool = false { didSet { someBoolSetCallCount += 1 } }

    private(set) var doSomethingCallCount = 0
    var doSomethingHandler: (() -> ())?
    func doSomething()  {
        doSomethingCallCount += 1
        if let doSomethingHandler = doSomethingHandler {
            doSomethingHandler()
        }
        
    }

    private(set) var doSomethingSpecialCallCount = 0
    var doSomethingSpecialHandler: (() -> ())?
    func doSomethingSpecial()  {
        doSomethingSpecialCallCount += 1
        if let doSomethingSpecialHandler = doSomethingSpecialHandler {
            doSomethingSpecialHandler()
        }
        
    }
}


```


- close #170


## Solution

checking if inheritedType is `CompositionType` or not.

- Abstract Syntax Tree
![Screenshot 2023-03-04 at 16 35 08](https://user-images.githubusercontent.com/44002126/222882625-3760ac9e-4cac-4e91-af26-b1ddbf87dda2.png)
