### PR TITLE
Fix Import for SwiftSyntax and SwiftSyntaxParser

### DIFF
--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -15,7 +15,12 @@
 //
 
 import Foundation
+#if canImport(SwiftSyntax)
 import SwiftSyntax
+#endif
+#if canImport(SwiftSyntaxParser)
+import SwiftSyntaxParser
+#endif
 
 extension Int {
     var tab: String {


### PR DESCRIPTION
**Issue**
In `StringExtension` `SwiftSyntax` was directly imported without a `canImport` check
https://github.com/uber/mockolo/blob/2b425df144b0a1e61bf2202d481637741b2b3270/Sources/MockoloFramework/Utils/StringExtensions.swift#L18

Changelog
- Wrap the `SwiftSyntax ` and `SwiftSyntaxParser ` imports inside `canImport`