### PR TITLE
Use lib_InternalSwiftSyntaxParser resolved by SPM

### DIFF
--- a/install-script.sh
+++ b/install-script.sh
@@ -69,7 +69,6 @@ swift build -c release --arch arm64 --arch x86_64
 cd .build/apple/Products/Release
 
 echo "** Install..."
-cp "$(xcode-select -p)"/Toolchains/XcodeDefault.xctoolchain/usr/lib/swift/macosx/lib_InternalSwiftSyntaxParser.dylib . 
 
 install_name_tool -change @rpath/lib_InternalSwiftSyntaxParser.dylib @executable_path/lib_InternalSwiftSyntaxParser.dylib "$TARGET"
 


### PR DESCRIPTION
## Overview

One of the install option; downloading mockolo.tar.gz does not work if  we generate mockolo binary with`lib_InternalSwiftSyntaxParser` which is placed inside Xcode toolchain.

I think there is no need to copy `lib_internalSwiftSyntaxParser.dylib` from xcode toolchain and we can just use one resolved by running `swift build`.

please feel free to correct me if there is a better way.

## Issue

- close #219 
