### PR TITLE
update swift-syntax to 508.0.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -14,7 +14,10 @@ dependencies.append(.package(url: "https://github.com/apple/swift-argument-parse
 dependencies.append(.package(url: "https://github.com/apple/swift-argument-parser", "1.0.1"..."1.0.3"))
 #endif
 
-#if swift(>=5.7)
+#if swift(>=5.8)
+dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("508.0.0")))
+mockoloFrameworkTargetDependencies.append(.product(name: "SwiftParser", package: "SwiftSyntax"))
+#elseif swift(>=5.7)
 dependencies.append(.package(name: "SwiftSyntax", url: "https://github.com/apple/swift-syntax.git", .exact("0.50700.1")))
 mockoloFrameworkTargetDependencies.append(.product(name: "SwiftSyntaxParser", package: "SwiftSyntax"))
 #elseif swift(>=5.6)

--- a/Sources/MockoloFramework/Parsers/SourceParser.swift
+++ b/Sources/MockoloFramework/Parsers/SourceParser.swift
@@ -18,8 +18,8 @@ import Foundation
 #if canImport(SwiftSyntax)
 import SwiftSyntax
 #endif
-#if canImport(SwiftSyntaxParser)
-import SwiftSyntaxParser
+#if canImport(SwiftParser)
+import SwiftParser
 #endif
 
 public enum DeclType {
@@ -91,7 +91,7 @@ public class SourceParser {
 
         do {
             var results = [Entity]()
-            let node = try SyntaxParser.parse(path)
+            let node = try Parser.parse(path)
             let treeVisitor = EntityVisitor(path, annotation: annotation, fileMacro: fileMacro, declType: declType)
             treeVisitor.walk(node)
             let ret = treeVisitor.entities

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -9,24 +9,24 @@ import Foundation
 #if canImport(SwiftSyntax)
 import SwiftSyntax
 #endif
-#if canImport(SwiftSyntaxParser)
-import SwiftSyntaxParser
+#if canImport(SwiftParser)
+import SwiftParser
 #endif
 
-extension SyntaxParser {
-    public static func parse(_ fileData: Data, path: String) throws -> SourceFileSyntax {
+extension Parser {
+    public static func parse(_ fileData: Data, path: String) -> SourceFileSyntax {
         // Avoid using `String(contentsOf:)` because it creates a wrapped NSString.
         let source = fileData.withUnsafeBytes { buf in
             return String(decoding: buf.bindMemory(to: UInt8.self), as: UTF8.self)
         }
-        return try parse(source: source, filenameForDiagnostics: path)
+        return parse(source: source)
     }
 
-    public static func parse(_ path: String) throws -> SourceFileSyntax {
+    public static func parse(_ path: String) -> SourceFileSyntax {
         guard let fileData = FileManager.default.contents(atPath: path) else {
             fatalError("Retrieving contents of \(path) failed")
         }
-        return try parse(fileData, path: path)
+        return parse(fileData, path: path)
     }
 }
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -248,7 +248,7 @@ extension IfConfigDeclSyntax {
         var name = ""
         for cl in self.clauses {
             if let desc = cl.condition?.description {
-                if let list = cl.elements.as(MemberDeclListSyntax.self) {
+                if let list = cl.elements?.as(MemberDeclListSyntax.self) {
                     name = desc
                     for element in list {
                         if let (item, attr, initFlag) = element.transformToModel(with: encloserAcl, declType: declType, metadata: metadata, processed: processed) {
@@ -483,7 +483,7 @@ extension InitializerDeclSyntax {
     func model(with acl: String, declType: DeclType, processed: Bool) -> Model {
         let requiredInit = isRequired(with: declType)
 
-        let params = self.parameters.parameterList.compactMap { $0.model(inInit: true, declType: declType) }
+        let params = self.signature.input.parameterList.compactMap { $0.model(inInit: true, declType: declType) }
         let genericTypeParams = self.genericParameterClause?.genericParameterList.compactMap { $0.model(inInit: true) } ?? []
         let genericWhereClause = self.genericWhereClause?.description
 
@@ -495,7 +495,7 @@ extension InitializerDeclSyntax {
                            genericTypeParams: genericTypeParams,
                            genericWhereClause: genericWhereClause,
                            params: params,
-                           throwsOrRethrows: self.throwsOrRethrowsKeyword?.text,
+                           throwsOrRethrows: self.signature.throwsOrRethrowsKeyword?.text,
                            asyncOrReasync: nil, // "init() async" is not supperted in SwiftSyntax
                            isStatic: false,
                            offset: self.offset,
@@ -581,7 +581,7 @@ extension AssociatedtypeDeclSyntax {
 extension TypealiasDeclSyntax {
     func model(with acl: String, declType: DeclType, overrides: [String: String]?, processed: Bool) -> Model {
         return TypeAliasModel(name: self.identifier.text,
-                              typeName: self.initializer?.value.description ?? "",
+                              typeName: self.initializer.value.description,
                               acl: acl,
                               encloserType: declType,
                               overrideTypes: overrides,
@@ -605,6 +605,7 @@ final class EntityVisitor: SyntaxVisitor {
         self.fileMacro = fileMacro ?? ""
         self.path = path
         self.declType = declType
+        super.init(viewMode: .sourceAccurate)
     }
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind { visitImpl(node) }
@@ -664,7 +665,7 @@ final class EntityVisitor: SyntaxVisitor {
 
             guard macroName != fileMacro else { return .visitChildren }
 
-            if let list = cl.elements.as(CodeBlockItemListSyntax.self) {
+            if let list = cl.elements?.as(CodeBlockItemListSyntax.self) {
                 for el in list {
                     if let importItem = el.item.as(ImportDeclSyntax.self) {
                         let key = macroName

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -354,17 +354,7 @@ extension TokenKind {
         case "try":
           self = .tryKeyword
         case "throws":
-          self = .throwsKeyword
-        case "__FILE__":
-          self = .__file__Keyword
-        case "__LINE__":
-          self = .__line__Keyword
-        case "__COLUMN__":
-          self = .__column__Keyword
-        case "__FUNCTION__":
-          self = .__function__Keyword
-        case "__DSO_HANDLE__":
-          self = .__dso_handle__Keyword
+          self = .throwsKeyword        
         case "_":
           self = .wildcardKeyword
         case "#keyPath":


### PR DESCRIPTION
## Overview
Update swift-syntax to 508.0.0

- Use SwiftParser instead of SwiftSyntaxParser
- This can resolve issues related to lib_InternalSwiftSyntaxParser.dylib
    - SwiftParser does not depend on lib_InternalSwiftSyntaxParser.dylib

## Problem
Difficulty in supporting compilation with older Swift versions (below Swift 5.8)

- SwiftParser and SwiftSyntaxParser are different libraries, making it challenging for Mockolo to depend on them in the codebase.

I created additional PR to support old swift versions. I don't think it can be merged into master because of its complexity.

- https://github.com/fummicc1/mockolo/pull/1


## Issue

- #226 