### PR TITLE
Add support to build on macOS 12

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,9 +12,10 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, ubuntu-latest]
+        os: [macos-12, macos-13, ubuntu-latest]
     steps:
       - uses: swift-actions/setup-swift@v1
+        if: runner.os == 'Linux'
         with:
           swift-version: "5.8"
       - name: Checkout

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.8
+// swift-tools-version:5.7
 import PackageDescription
 
 let package = Package(

--- a/README.md
+++ b/README.md
@@ -21,9 +21,9 @@ This project may contain unstable APIs which may not be ready for general use. S
 
 ## System Requirements
 
-* Swift 5.4 or later
-* Xcode 12.5 or later
-* macOS 11.0 or later
+* Swift 5.7 or later
+* Xcode 14.2 or later
+* macOS 12.0 or later and Linux
 * Support is included for the Swift Package Manager
 
 


### PR DESCRIPTION
To support building homebrew bottle on macOS 12, set swift-tools-version to 5.7.

(The latest Xcode that macOS11 can use is 13.2.1, and it is too old so I give up.