### PR TITLE
[Combine] can set default value to `CurrentValueSubject`

### DIFF
--- a/README.md
+++ b/README.md
@@ -361,6 +361,28 @@ public class FooMock: Foo {
 }
 ```
 
+Warning: If you would like to send a custom data event via `Publisher`, it is hard to specify default value from mockolo this is why `PassthroughSubject` is used insteaad of `CurrentValueSubject` regardless of your specification.
+As a solution, you can set a default value via metadata like the following.
+
+```swift
+/// @mockable(combine: fooPublisher = CurrentValueSubject; default = CustomType())
+public protocol Foo {
+    var fooPublisher: AnyPublisher<CustomType, CustomError> { get }
+}
+```
+
+This will generate:
+
+```swift
+public class FooMock: Foo {
+    public init() { }
+
+
+    public var fooPublisher: AnyPublisher<CustomType, CustomError> { return self.fooPublisherSubject.eraseToAnyPublisher() }
+    public private(set) var fooPublisherSubject = CurrentValueSubject<CustomType, CustomError>(CustomType())
+}
+```
+ 
 You can also connect an AnyPublisher to a property within the protocol.
 
 For example:

--- a/README.md
+++ b/README.md
@@ -361,8 +361,9 @@ public class FooMock: Foo {
 }
 ```
 
-Warning: If you would like to send a custom data event via `Publisher`, it is hard to specify default value from mockolo this is why `PassthroughSubject` is used insteaad of `CurrentValueSubject` regardless of your specification.
-As a solution, you can set a default value via metadata like the following.
+Warning: If you would like to send a value of custom type via `Publisher`, it is hard to decide default value from mockolo.
+This is why `PassthroughSubject` is used instead of `CurrentValueSubject` regardless of your specification.
+As a solution, please set a default value via metadata like the following.
 
 ```swift
 /// @mockable(combine: fooPublisher = CurrentValueSubject; default = CustomType())

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -103,7 +103,7 @@ final class EntityNodeSubContainer {
 
 public enum CombineType {
     case passthroughSubject
-    case currentValueSubject(defaultValueFromMetadata: String?)
+    case currentValueSubject(defaultValue: String?)
     case property(wrapper: String, name: String)
 
     var typeName: String {

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -103,7 +103,7 @@ final class EntityNodeSubContainer {
 
 public enum CombineType {
     case passthroughSubject
-    case currentValueSubject
+    case currentValueSubject(defaultValueFromMetadata: String?)
     case property(wrapper: String, name: String)
 
     var typeName: String {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -743,7 +743,7 @@ extension Trivia {
 
             ret.combineTypes = ret.combineTypes ?? [String: CombineType]()
 
-            let currentValueSubjectStr = CombineType.currentValueSubject.typeName.lowercased()
+            let currentValueSubjectStr = CombineType.currentValueSubject(defaultValueFromMetadata: nil).typeName.lowercased()
             for pair in arguments {
                 if pair.value.hasPrefix("@") {
                     let parts = pair.value.split(separator: " ")
@@ -754,7 +754,8 @@ extension Trivia {
                 }
 
                 if pair.value.lowercased() == currentValueSubjectStr {
-                    ret.combineTypes?[pair.key] = .currentValueSubject
+                    let defaultValue = arguments["default"]
+                    ret.combineTypes?[pair.key] = .currentValueSubject(defaultValueFromMetadata: defaultValue)
                 } else {
                     ret.combineTypes?[pair.key] = .passthroughSubject
                 }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -689,11 +689,11 @@ final class EntityVisitor: SyntaxVisitor {
 }
 
 extension Trivia {
-    // This parses arguments in annotation which can be used to override certain types.
-    //
-    // E.g. given /// @mockable(typealias: T = Any; U = AnyObject), it returns
-    // a dictionary: [T: Any, U: AnyObject] which will be used to override inhertied types
-    // of typealias decls for T and U.
+    /// This parses arguments in annotation which can be used to override certain types.
+    ///
+    /// E.g. given `/// @mockable(typealias: T = Any; U = AnyObject)`,
+    /// it returns a dictionary: `[T: Any, U: AnyObject]` which will be used to override inhertied types
+    /// of typealias decls for T and U.
     private func metadata(with annotation: String, in val: String) -> AnnotationMetadata? {
         guard val.contains(annotation) else {
             return nil

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -743,7 +743,7 @@ extension Trivia {
 
             ret.combineTypes = ret.combineTypes ?? [String: CombineType]()
 
-            let currentValueSubjectStr = CombineType.currentValueSubject(defaultValueFromMetadata: nil).typeName.lowercased()
+            let currentValueSubjectStr = CombineType.currentValueSubject(defaultValue: nil).typeName.lowercased()
             for pair in arguments {
                 if pair.value.hasPrefix("@") {
                     let parts = pair.value.split(separator: " ")
@@ -755,7 +755,7 @@ extension Trivia {
 
                 if pair.value.lowercased() == currentValueSubjectStr {
                     let defaultValue = arguments["default"]
-                    ret.combineTypes?[pair.key] = .currentValueSubject(defaultValueFromMetadata: defaultValue)
+                    ret.combineTypes?[pair.key] = .currentValueSubject(defaultValue: defaultValue)
                 } else {
                     ret.combineTypes?[pair.key] = .passthroughSubject
                 }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -147,8 +147,8 @@ extension VariableModel {
             var combineSubjectType = combineType ?? .passthroughSubject
 
             var defaultValue: String? = ""
-            if case let .currentValueSubject(defaultValueFromMetadata) = combineSubjectType {
-                defaultValue = defaultValueFromMetadata ?? subjectDefaultValue
+            if case let .currentValueSubject(`default`) = combineSubjectType {
+                defaultValue = `default` ?? subjectDefaultValue
             }
 
             // Unable to generate default value for this CurrentValueSubject. Default back to PassthroughSubject.

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -147,8 +147,8 @@ extension VariableModel {
             var combineSubjectType = combineType ?? .passthroughSubject
 
             var defaultValue: String? = ""
-            if case .currentValueSubject = combineSubjectType {
-                defaultValue = subjectDefaultValue
+            if case let .currentValueSubject(defaultValueFromMetadata) = combineSubjectType {
+                defaultValue = defaultValueFromMetadata ?? subjectDefaultValue
             }
 
             // Unable to generate default value for this CurrentValueSubject. Default back to PassthroughSubject.

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -392,7 +392,7 @@ public final class `Type` {
             } else if subjectKind == String.replaySubject {
                 underlyingSubjectTypeDefaultVal = "\(underlyingSubjectType)\(String.replaySubjectCreate)"
             } else if subjectKind == String.behaviorSubject {
-                if let val = Type(String(typeParamStr)).defaultSingularVal(isInitParam: isInitParam, overrides: overrides, overrideKey: overrideKey) {
+                if let val = Type(String(typeParamStr)).defaultSingularVal(overrides: overrides, overrideKey: overrideKey) {
                     underlyingSubjectTypeDefaultVal = "\(underlyingSubjectType)(value: \(val))"
                 }
             }
@@ -404,7 +404,7 @@ public final class `Type` {
     private func parseDefaultVal(isInitParam: Bool) -> String? {
         let arg = self
 
-        if let val = defaultSingularVal(isInitParam: isInitParam) {
+        if let val = defaultSingularVal() {
             return val
         }
 
@@ -422,7 +422,7 @@ public final class `Type` {
             if sub == "," || sub == ":" || sub == "(" || sub == ")" || sub == "=" || sub == " " || sub == "" {
                 vals.append(sub)
             } else {
-                if let val = Type(sub).defaultSingularVal(isInitParam: isInitParam) {
+                if let val = Type(sub).defaultSingularVal() {
                     vals.append(val)
                 } else {
                     return nil
@@ -440,7 +440,10 @@ public final class `Type` {
         return nil
     }
 
-    private func defaultSingularVal(isInitParam: Bool = false, overrides: [String: String]? = nil, overrideKey: String = "") -> String? {
+    private func defaultSingularVal(
+        overrides: [String: String]? = nil,
+        overrideKey: String = ""
+    ) -> String? {
         let arg = self
 
         if arg.isOptional {

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -337,7 +337,11 @@ public final class `Type` {
     ///  if "nil", type is optional
     ///  if "non-nil", type is non-optional
     ///  if "", type is String, with an empty string value
-    func defaultVal(with overrides: [String: String]? = nil, overrideKey: String = "", isInitParam: Bool = false) -> String? {
+    func defaultVal(
+        with overrides: [String: String]? = nil,
+        overrideKey: String = "",
+        isInitParam: Bool = false
+    ) -> String? {
 
         if let val = cachedDefaultVal {
             return val
@@ -366,7 +370,11 @@ public final class `Type` {
         return nil
     }
 
-    func parseRxVar(overrides: [String: String]?, overrideKey: String, isInitParam: Bool) -> (String?, String?, String?) {
+    func parseRxVar(
+        overrides: [String: String]?,
+        overrideKey: String,
+        isInitParam: Bool
+    ) -> (String?, String?, String?) {
         if typeName.hasPrefix(String.observableLeftAngleBracket) || typeName.hasPrefix(String.rxObservableLeftAngleBracket),
             let range = typeName.range(of: String.observableLeftAngleBracket), let lastIdx = typeName.lastIndex(of: ">") {
             let typeParamStr = typeName[range.upperBound..<lastIdx]

--- a/Tests/TestCombine/CombineTests.swift
+++ b/Tests/TestCombine/CombineTests.swift
@@ -34,5 +34,12 @@ class CombineTests: MockoloTestCase {
                disableCombineDefaultValues: true
             )
     }
+
+    func testCombine_currentValueSubject_defaultValue() {
+        verify(
+            srcContent: combineDefaultSubjectProtocol,
+            dstContent: combineDefaultSubjectProtocolMock
+        )
+    }
 }
 

--- a/Tests/TestCombine/FixtureCombine.swift
+++ b/Tests/TestCombine/FixtureCombine.swift
@@ -247,3 +247,20 @@ public class FooMock: Foo {
     }
 }
 """
+
+let combineDefaultSubjectProtocol = """
+/// \(String.mockAnnotation)(combine: myCustomTypePublisher = CurrentValueSubject; default = MyCustomType(value: "foo"))
+public protocol FooDefaultSubjectValue {
+    var myCustomTypePublisher: AnyPublisher<MyCustomType?, Error> { get }
+}
+"""
+
+let combineDefaultSubjectProtocolMock = """
+public class FooDefaultSubjectValueMock: FooDefaultSubjectValue {
+    public init() { }
+
+
+    public var myCustomTypePublisher: AnyPublisher<MyCustomType?, Error> { return self.myCustomTypePublisherSubject.eraseToAnyPublisher() }
+    public private(set) var myCustomTypePublisherSubject = CurrentValueSubject<MyCustomType?, Error>(MyCustomType(value: "foo"))
+}
+"""


### PR DESCRIPTION
## Overview

I added new metadata to set an explicit default value for CurrentValueSubject in a Mock object, which is used to manage the Publisher stream.

### Problem

Currently, if publish type ( type `A` of `Publisher<A, B>`) is not kind of primitive type, subject becomes `PassthroughSubject` even if you mark it as `CurrentValueSubject` by `@mockable(combine: aPublisher = CurrentValueSubject)`.

### Note
This PR only addresses Combine, but RxSwift also has the same problem. I believe this should be considered a separate issue because the implementation differs from the Combine one.

### Example

<img width="1548" alt="Screenshot 2023-05-03 at 23 49 51" src="https://user-images.githubusercontent.com/44002126/235965897-60e00a8d-6028-4b15-bd54-504307ed5595.png">


