### PR TITLE
Drop legacy sequence extensions

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -25,9 +25,9 @@ final class ArgumentsHistoryModel: Model {
         self.isHistoryAnnotated = isHistoryAnnotated
 
         self.capturableParamNames = capturables.map(\.name.safeName)
-        self.capturableParamTypes = capturables.map(path: \.type)
+        self.capturableParamTypes = capturables.map(\.type)
         
-        let genericTypeNameList = genericTypeParams.map(path: \.name)
+        let genericTypeNameList = genericTypeParams.map(\.name)
         self.type = Type.toArgumentsHistoryType(with: capturableParamTypes, typeParams: genericTypeNameList)
     }
     

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -34,7 +34,7 @@ final class ClosureModel: Model {
     init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type, encloser: String) {
         self.name = name + .handlerSuffix
         self.suffix = suffix
-        let genericTypeNameList = genericTypeParams.map(path: \.name)
+        let genericTypeNameList = genericTypeParams.map(\.name)
         self.genericTypeNames = genericTypeNameList
         self.paramNames = paramNames
         self.paramTypes = paramTypes

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -66,8 +66,8 @@ final class MethodModel: Model {
 
     lazy var signatureComponents: [String] = {
         let paramLabels = self.params.map {$0.label != "_" ? $0.label : ""}
-        let paramNames = self.params.map(path: \.name)
-        let paramTypes = self.params.map(path: \.type)
+        let paramNames = self.params.map(\.name)
+        let paramTypes = self.params.map(\.type)
         let nameString = self.name
         var args = zip(paramLabels, paramNames).compactMap { (argLabel: String, argName: String) -> String? in
             let val = argLabel.isEmpty ? argName : argLabel
@@ -80,7 +80,7 @@ final class MethodModel: Model {
         let genericTypeNames = self.genericTypeParams.map { $0.name.capitalizeFirstLetter + $0.type.displayName }
         args.append(contentsOf: genericTypeNames)
 
-        args.append(contentsOf: paramTypes.map(path: \.displayName))
+        args.append(contentsOf: paramTypes.map(\.displayName))
         var displayType = self.type.displayName
         let capped = min(displayType.count, 32)
         displayType.removeLast(displayType.count-capped)
@@ -109,8 +109,8 @@ final class MethodModel: Model {
             return nil
         }
 
-        let paramNames = self.params.map(path: \.name)
-        let paramTypes = self.params.map(path: \.type)
+        let paramNames = self.params.map(\.name)
+        let paramTypes = self.params.map(\.type)
         let ret = ClosureModel(name: name,
                                genericTypeParams: genericTypeParams,
                                paramNames: paramNames,

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -52,7 +52,7 @@ struct ResolvedEntity {
         // Named params in init should be unique. Add a duplicate param check to ensure it.
         let curVarsSorted = unprocessed.sorted(path: \.offset, fallback: \.name)
 
-        let curVarNames = curVarsSorted.map(path: \.name)
+        let curVarNames = curVarsSorted.map(\.name)
         let parentVars = processed.filter {!curVarNames.contains($0.name)}
         let parentVarsSorted = parentVars.sorted(path: \.offset, fallback: \.name)
         let result = [curVarsSorted, parentVarsSorted].flatMap{$0}

--- a/Sources/MockoloFramework/Utils/SequenceExtensions.swift
+++ b/Sources/MockoloFramework/Utils/SequenceExtensions.swift
@@ -17,40 +17,20 @@
 
 import Foundation
 
-public extension Sequence {
-    
-    func compactMap<T>(path: KeyPath<Element, T?>) -> [T] {
-        return compactMap { (element) -> T? in
-            element[keyPath: path]
-        }
-    }
-    func map<T>(path: KeyPath<Element, T>) -> [T] {
-        return map { (element) -> T in
-            element[keyPath: path]
-        }
-    }
-    
-    func filter(path: KeyPath<Element, Bool>) -> [Element] {
-        return filter { (element) -> Bool in
-            element[keyPath: path]
-        }
-    }
-    
-    func sorted<T>(path: KeyPath<Element, T>) -> [Element] where T: Comparable {
+extension Sequence {
+    func sorted<T>(path: (Element) -> T) -> [Element] where T: Comparable {
         return sorted { (lhs, rhs) -> Bool in
-            lhs[keyPath: path] < rhs[keyPath: path]
+            path(lhs) < path(rhs)
         }
     }
 
-    func sorted<T, U>(path: KeyPath<Element, T>, fallback: KeyPath<Element, U>) -> [Element] where T: Comparable, U: Comparable {
+    func sorted<T, U>(path: (Element) -> T, fallback: (Element) -> U) -> [Element] where T: Comparable, U: Comparable {
         return sorted { (lhs, rhs) -> Bool in
-            if lhs[keyPath: path] == rhs[keyPath: path] {
-                return lhs[keyPath: fallback] < rhs[keyPath: fallback]
+            if path(lhs) == path(rhs) {
+                return fallback(lhs) < fallback(rhs)
             }
 
-            return lhs[keyPath: path] < rhs[keyPath: path]
+            return path(lhs) < path(rhs)
         }
     }
 }
-
-


### PR DESCRIPTION
This is simple cleaning PR.

With the [SE-0249](https://github.com/apple/swift-evolution/blob/main/proposals/0249-key-path-literal-function-expressions.md), some extensions can get be useable without it.

