### PR TITLE
[Bugfix] Fix functions with same signature and different generic constraints not getting generated

### DIFF
--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -122,6 +122,9 @@ final class MethodModel: Model {
         displayType.removeLast(displayType.count-capped)
         args.append(displayType)
         args.append(self.staticKind)
+        if let genericWhereClause {
+            args.append(genericWhereClauseToSignatureComponent)
+        }
         let ret = args.filter{ arg in !arg.isEmpty }
         return ret
     }()

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -49,6 +49,40 @@ final class MethodModel: Model {
     private var staticKind: String {
         return isStatic ? .static : ""
     }
+    
+    /// This is used to uniquely identify methods with the same signature and different generic requirements
+    var genericWhereClauseToSignatureComponent: String {
+        guard let genericWhereClause else {
+            return ""
+        }
+        let typeRequirementSyntax = ":"
+        let typeEqualitySyntax = "=="
+        
+        var signatureComponents: [String] = []
+        
+        genericWhereClause.deletingPrefix("where").components(separatedBy: ",").forEach { requirement in
+            if requirement.contains(typeRequirementSyntax) {
+                let components = requirement.components(separatedBy: typeRequirementSyntax).map{ $0.trimmingCharacters(in: .whitespaces) }
+                guard let key = components.first, let value = components.last else {
+                    return
+                }
+                let valueDescription = value.replacingOccurrences(of: " ", with: "").replacingOccurrences(of: "&", with: "And")
+                signatureComponents.append(contentsOf: [key, valueDescription])
+            } else if requirement.contains(typeEqualitySyntax) {
+                let components = requirement.components(separatedBy: typeEqualitySyntax).map{ $0.trimmingCharacters(in: .whitespaces) }
+                guard let key = components.first, let value = components.last else {
+                    return
+                }
+                signatureComponents.append(contentsOf: [key, value])
+            }
+        }
+        
+        return signatureComponents.map { component in
+            var newComponent = component
+            newComponent.removeAll(where: { $0 == "."})
+            return newComponent
+        }.joined()
+    }
 
     var isInitializer: Bool {
         if case .initKind(_, _) = kind {
@@ -79,8 +113,9 @@ final class MethodModel: Model {
 
         let genericTypeNames = self.genericTypeParams.map { $0.name.capitalizeFirstLetter + $0.type.displayName }
         args.append(contentsOf: genericTypeNames)
-        let genericWhereClause = self.genericWhereClause?.replacingOccurrences(of: " ", with: "_") ?? ""
-        args.append(genericWhereClause)
+        if let genericWhereClause {
+            args.append(genericWhereClauseToSignatureComponent)
+        }
         args.append(contentsOf: paramTypes.map(\.displayName))
         var displayType = self.type.displayName
         let capped = min(displayType.count, 32)

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -122,9 +122,6 @@ final class MethodModel: Model {
         displayType.removeLast(displayType.count-capped)
         args.append(displayType)
         args.append(self.staticKind)
-        if let genericWhereClause {
-            args.append(genericWhereClauseToSignatureComponent)
-        }
         let ret = args.filter{ arg in !arg.isEmpty }
         return ret
     }()

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -79,7 +79,8 @@ final class MethodModel: Model {
 
         let genericTypeNames = self.genericTypeParams.map { $0.name.capitalizeFirstLetter + $0.type.displayName }
         args.append(contentsOf: genericTypeNames)
-
+        let genericWhereClause = self.genericWhereClause?.replacingOccurrences(of: " ", with: "_") ?? ""
+        args.append(genericWhereClause)
         args.append(contentsOf: paramTypes.map(\.displayName))
         var displayType = self.type.displayName
         let capped = min(displayType.count, 32)

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -190,6 +190,11 @@ extension String {
         }
         return !argsMap.isEmpty ? argsMap : nil
     }
+    
+    func deletingPrefix(_ prefix: String) -> String {
+        guard self.hasPrefix(prefix) else { return self }
+        return String(self.dropFirst(prefix.count))
+    }
 }
 
 let separatorsForDisplay = CharacterSet(charactersIn: "<>[] :,()_-.&@#!{}@+\"\'")

--- a/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
+++ b/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
@@ -229,3 +229,39 @@ class NetworkingMock: Networking {
 }
 """
 
+let funcDuplicateSignatureDifferentWhereClause = """
+/// \(String.mockAnnotation)
+protocol Storing {
+   func connect<T>(adapter: T) where T: Adapter
+   func connect<T>(adapter: T) where T: KeyedAdapter
+}
+"""
+
+let funcDuplicateSignatureDifferentWhereClauseMock = """
+class StoringMock: Storing {
+    init() { }
+
+
+    private(set) var connectCallCount = 0
+    var connectHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: Adapter {
+        connectCallCount += 1
+        if let connectHandler = connectHandler {
+            connectHandler(adapter)
+        }
+        
+    }
+
+    private(set) var connectAdapterCallCount = 0
+    var connectAdapterHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter {
+        connectAdapterCallCount += 1
+        if let connectAdapterHandler = connectAdapterHandler {
+            connectAdapterHandler(adapter)
+        }
+        
+    }
+}
+
+
+"""

--- a/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
+++ b/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
@@ -234,6 +234,8 @@ let funcDuplicateSignatureDifferentWhereClause = """
 protocol Storing {
    func connect<T>(adapter: T) where T: Adapter
    func connect<T>(adapter: T) where T: KeyedAdapter
+   func connect<T>(adapter: T) where T: KeyedAdapter2
+   func connect<T>(adapter: T) where T: KeyedAdapter3
 }
 """
 
@@ -261,7 +263,82 @@ class StoringMock: Storing {
         }
         
     }
+
+    private(set) var connectAdapterTCallCount = 0
+    var connectAdapterTHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter2 {
+        connectAdapterTCallCount += 1
+        if let connectAdapterTHandler = connectAdapterTHandler {
+            connectAdapterTHandler(adapter)
+        }
+        
+    }
+
+    private(set) var connectAdapterTTKeyedAdapter3CallCount = 0
+    var connectAdapterTTKeyedAdapter3Handler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter3 {
+        connectAdapterTTKeyedAdapter3CallCount += 1
+        if let connectAdapterTTKeyedAdapter3Handler = connectAdapterTTKeyedAdapter3Handler {
+            connectAdapterTTKeyedAdapter3Handler(adapter)
+        }
+        
+    }
 }
+"""
+
+let funcDuplicateSignatureDifferentWhereClauseEquality = """
+/// \(String.mockAnnotation)
+protocol Storing<S: Sequence> {
+   func connect<T>(adapter: T) where T: Adapter, T.Element == S.Element
+   func connect<T>(adapter: T) where T: KeyedAdapter, T.Element == S.Element
+   func connect<T>(adapter: T) where T: KeyedAdapter2, T.Element == S.Element
+   func connect<T>(adapter: T) where T: KeyedAdapter3, T.Element == S.Element
+}
+"""
+
+let funcDuplicateSignatureDifferentWhereClauseEqualityMock = """
+class StoringMock: Storing {
+    init() { }
 
 
+    private(set) var connectCallCount = 0
+    var connectHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: Adapter, T.Element == S.Element {
+        connectCallCount += 1
+        if let connectHandler = connectHandler {
+            connectHandler(adapter)
+        }
+        
+    }
+
+    private(set) var connectAdapterCallCount = 0
+    var connectAdapterHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter, T.Element == S.Element {
+        connectAdapterCallCount += 1
+        if let connectAdapterHandler = connectAdapterHandler {
+            connectAdapterHandler(adapter)
+        }
+        
+    }
+
+    private(set) var connectAdapterTCallCount = 0
+    var connectAdapterTHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter2, T.Element == S.Element {
+        connectAdapterTCallCount += 1
+        if let connectAdapterTHandler = connectAdapterTHandler {
+            connectAdapterTHandler(adapter)
+        }
+        
+    }
+
+    private(set) var connectAdapterTTKeyedAdapter3TElementSElementCallCount = 0
+    var connectAdapterTTKeyedAdapter3TElementSElementHandler: ((Any) -> ())?
+    func connect<T>(adapter: T)  where T: KeyedAdapter3, T.Element == S.Element {
+        connectAdapterTTKeyedAdapter3TElementSElementCallCount += 1
+        if let connectAdapterTTKeyedAdapter3TElementSElementHandler = connectAdapterTTKeyedAdapter3TElementSElementHandler {
+            connectAdapterTTKeyedAdapter3TElementSElementHandler(adapter)
+        }
+        
+    }
+}
 """

--- a/Tests/TestFuncs/TestGenericFuncs/GenericFuncTests.swift
+++ b/Tests/TestFuncs/TestGenericFuncs/GenericFuncTests.swift
@@ -16,6 +16,11 @@ class GenericFuncTests: MockoloTestCase {
         verify(srcContent: funcWhereClause,
                dstContent: funcWhereClauseMock)
     }
+    
+    func testWhereClauseWithSameSignature() {
+        verify(srcContent: funcDuplicateSignatureDifferentWhereClause,
+               dstContent: funcDuplicateSignatureDifferentWhereClauseMock)
+    }
 }
 
 

--- a/Tests/TestFuncs/TestGenericFuncs/GenericFuncTests.swift
+++ b/Tests/TestFuncs/TestGenericFuncs/GenericFuncTests.swift
@@ -21,6 +21,11 @@ class GenericFuncTests: MockoloTestCase {
         verify(srcContent: funcDuplicateSignatureDifferentWhereClause,
                dstContent: funcDuplicateSignatureDifferentWhereClauseMock)
     }
+    
+    func testWhereClauseWithSameSignatureAndEqualityConstraints() {
+        verify(srcContent: funcDuplicateSignatureDifferentWhereClauseEquality,
+               dstContent: funcDuplicateSignatureDifferentWhereClauseEqualityMock)
+    }
 }
 
 


### PR DESCRIPTION
A mock file will fail to compile if the protocol being mocked contains two functions with the same signature and name but has different generic constraints. Consider the following example:
```
@CreateMock
protocol Foo {
   func connect<T>(adapter: T) where T: Adapter
   func connect<T>(adapter: T) where T: KeyedAdapter
}
```
The above code will generate the following mock:
```
public var connectCallCount = 0    
public var connectHandler: ((Any) -> ())?    
public func connect<T>(adapter: T)  where T: Adapter {
   mockFunc(&connectCallCount)("connect", connectHandler?(adapter), .void)    
}
```
This fails to compile because it's missing the implementation with `KeyedAdapter`. With this PR, the following mock will now be produced

```
public var connectCallCount = 0
public var connectHandler: ((Any) -> ())?
public func connect<T>(adapter: T) where T: EntityAdapter {
    mockFunc(&connectCallCount)("connect", connectHandler?(adapter), .void)
}

public var connectAdapterCallCount =0
public var connectAdapterHandler: ((Any) -> ())?
public func connect<T>(adapter: T) where T: KeyedEntityAdapter {
    mockFunc(&connectAdapterCallCount)("connect", connectAdapterHandler?(adapter), .void)
}
```
 