### PR TITLE
Fix the version code concerning release

### DIFF
--- a/Sources/MockoloFramework/Version.swift
+++ b/Sources/MockoloFramework/Version.swift
@@ -3,5 +3,5 @@ public struct Version {
     public let value: String
 
     /// The current Mockolo version.
-    public static let current = Version(value: "2.0.0")
+    public static let current = Version(value: "2.0.1")
 }


### PR DESCRIPTION
The latest [release](https://github.com/uber/mockolo/releases/tag/2.0.1) of Mockolo has the old version `2.0.0`. It's a minor PR that aims to sync the version w.r.t to release.
