### PR TITLE
Support `Sendable` compliant protocols and classes

### DIFF
--- a/Sources/MockoloFramework/Models/ClassModel.swift
+++ b/Sources/MockoloFramework/Models/ClassModel.swift
@@ -24,11 +24,12 @@ final class ClassModel: Model {
     let accessLevel: String
     let identifier: String
     let declType: DeclType
+    let inheritedTypes: [String]
     let entities: [(String, Model)]
     let initParamCandidates: [VariableModel]
     let declaredInits: [MethodModel]
     let metadata: AnnotationMetadata?
-    
+
     var modelType: ModelType {
         return .class
     }
@@ -36,6 +37,7 @@ final class ClassModel: Model {
     init(identifier: String,
          acl: String,
          declType: DeclType,
+         inheritedTypes: [String],
          attributes: [String],
          offset: Int64,
          metadata: AnnotationMetadata?,
@@ -46,6 +48,7 @@ final class ClassModel: Model {
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
         self.type = Type(.class)
         self.declType = declType
+        self.inheritedTypes = inheritedTypes
         self.entities = entities
         self.declaredInits = declaredInits
         self.initParamCandidates = initParamCandidates
@@ -71,6 +74,7 @@ final class ClassModel: Model {
             accessLevel: accessLevel,
             attribute: attribute,
             declType: declType,
+            inheritedTypes: inheritedTypes,
             metadata: metadata,
             useTemplateFunc: useTemplateFunc,
             useMockObservable: useMockObservable,

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -22,6 +22,7 @@ struct ResolvedEntity {
     let entity: Entity
     let uniqueModels: [(String, Model)]
     let attributes: [String]
+    let inheritedTypes: [String]
 
     var declaredInits: [MethodModel] {
         return uniqueModels.filter {$0.1.isInitializer}.compactMap{ $0.1 as? MethodModel }
@@ -64,6 +65,7 @@ struct ResolvedEntity {
         return ClassModel(identifier: key,
                           acl: entity.entityNode.accessLevel,
                           declType: entity.entityNode.declType,
+                          inheritedTypes: inheritedTypes,
                           attributes: attributes,
                           offset: entity.entityNode.offset,
                           metadata: entity.metadata,

--- a/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
+++ b/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
@@ -35,8 +35,8 @@ private func generateUniqueModels(key: String,
                                   protocolMap: [String: Entity],
                                   inheritanceMap: [String: Entity]) -> ResolvedEntityContainer {
     
-    let (models, processedModels, attributes, paths, pathToContentList) = lookupEntities(key: key, declType: entity.entityNode.declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
-    
+    let (models, processedModels, attributes, inheritedTypes, paths, pathToContentList) = lookupEntities(key: key, declType: entity.entityNode.declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
+
     let processedFullNames = processedModels.compactMap {$0.fullName}
 
     let processedElements = processedModels.compactMap { (element: Model) -> (String, Model)? in
@@ -65,8 +65,13 @@ private func generateUniqueModels(key: String,
     let mockedUniqueEntities = Dictionary(uniqueKeysWithValues: processedElementsMap)
 
     let uniqueModels = [mockedUniqueEntities, unmockedUniqueEntities].flatMap {$0}
-    
-    let resolvedEntity = ResolvedEntity(key: key, entity: entity, uniqueModels: uniqueModels, attributes: attributes)
-    
+
+    var mockInheritedTypes = [String]()
+    if inheritedTypes.contains(.sendable) {
+        mockInheritedTypes.append(.uncheckedSendable)
+    }
+
+    let resolvedEntity = ResolvedEntity(key: key, entity: entity, uniqueModels: uniqueModels, attributes: attributes, inheritedTypes: mockInheritedTypes)
+
     return ResolvedEntityContainer(entity: resolvedEntity, paths: paths, imports: pathToContentList)
 }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -106,6 +106,11 @@ extension InheritanceClauseSyntax {
         } else if let compositionType = type.as(CompositionTypeSyntax.self) {
             // example: `protocol A: B & C {}`
             return compositionType.elements.map(\.type).map(parseElementType(type:)).flatMap { $0 }
+        } else if let attributedType = type.as(AttributedTypeSyntax.self) {
+            // example: `protocol A: @unchecked B {}`
+            if let baseType = attributedType.baseType.as(IdentifierTypeSyntax.self) {
+                return [baseType.name.text]
+            }
         }
         return []
     }

--- a/Sources/MockoloFramework/Templates/ClassTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClassTemplate.swift
@@ -22,6 +22,7 @@ extension ClassModel {
                             accessLevel: String,
                             attribute: String,
                             declType: DeclType,
+                            inheritedTypes: [String],
                             metadata: AnnotationMetadata?,
                             useTemplateFunc: Bool,
                             useMockObservable: Bool,
@@ -79,6 +80,11 @@ extension ClassModel {
         
         let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits,  acl: acl, declType: declType, overrides: metadata?.varTypes)
 
+        var inheritedTypesStr = ""
+        for inheritedType in inheritedTypes {
+            inheritedTypesStr += ", " + inheritedType
+        }
+
         var body = ""
         if !typealiasTemplate.isEmpty {
             body += "\(typealiasTemplate)\n"
@@ -93,7 +99,7 @@ extension ClassModel {
         let finalStr = mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)class \(name): \(moduleDot)\(identifier) {
+        \(acl)\(finalStr)class \(name): \(moduleDot)\(identifier)\(inheritedTypesStr) {
         \(body)
         }
         """

--- a/Sources/MockoloFramework/Templates/ClassTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClassTemplate.swift
@@ -80,10 +80,8 @@ extension ClassModel {
         
         let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits,  acl: acl, declType: declType, overrides: metadata?.varTypes)
 
-        var inheritedTypesStr = ""
-        for inheritedType in inheritedTypes {
-            inheritedTypesStr += ", " + inheritedType
-        }
+        var inheritedTypes = inheritedTypes
+        inheritedTypes.insert("\(moduleDot)\(identifier)", at: 0)
 
         var body = ""
         if !typealiasTemplate.isEmpty {
@@ -99,7 +97,7 @@ extension ClassModel {
         let finalStr = mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)class \(name): \(moduleDot)\(identifier)\(inheritedTypesStr) {
+        \(acl)\(finalStr)class \(name): \(inheritedTypes.joined(separator: ", ")) {
         \(body)
         }
         """

--- a/Sources/MockoloFramework/Utils/InheritanceResolver.swift
+++ b/Sources/MockoloFramework/Utils/InheritanceResolver.swift
@@ -23,18 +23,20 @@ import Foundation
 /// @param protocolMap Used to look up the current entity and its inheritance types
 /// @param inheritanceMap Used to look up inherited types if not contained in protocolMap
 /// @returns a list of models representing sub-entities of the current entity, a list of models processed in dependent mock files if exists,
-///          cumulated attributes, and a map of filepaths and file contents (used for import lines lookup later).
+///          cumulated attributes, cumulated inherited types, and a map of filepaths and file contents (used for import lines lookup later).
 func lookupEntities(key: String,
                     declType: DeclType,
                     protocolMap: [String: Entity],
-                    inheritanceMap: [String: Entity]) -> ([Model], [Model], [String], [String], [(String, Data, Int64)]) {
-    
+                    inheritanceMap: [String: Entity]) -> ([Model], [Model], [String], Set<String>, [String], [(String, Data, Int64)]) {
+
     // Used to keep track of types to be mocked
     var models = [Model]()
     // Used to keep track of types that were already mocked
     var processedModels = [Model]()
     // Gather attributes declared in current or parent protocols
     var attributes = [String]()
+    // Gather inherited types declared in current or parent protocols
+    var inheritedTypes = Set<String>()
     // Gather filepaths and contents used for imports
     var pathToContents = [(String, Data, Int64)]()
     // Gather filepaths used for imports
@@ -47,6 +49,7 @@ func lookupEntities(key: String,
         if !current.isProcessed {
             attributes.append(contentsOf: sub.attributes)
         }
+        inheritedTypes = inheritedTypes.union(current.entityNode.inheritedTypes)
         if let data = current.data {
             pathToContents.append((current.filepath, data, current.entityNode.offset))
         }
@@ -57,10 +60,11 @@ func lookupEntities(key: String,
             // If the protocol inherits other protocols, look up their entities as well.
             for parent in current.entityNode.inheritedTypes {
                 if parent != .class, parent != .anyType, parent != .anyObject {
-                    let (parentModels, parentProcessedModels, parentAttributes, parentPaths, parentPathToContents) = lookupEntities(key: parent, declType: declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
+                    let (parentModels, parentProcessedModels, parentAttributes, parentInheritedTypes, parentPaths, parentPathToContents) = lookupEntities(key: parent, declType: declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
                     models.append(contentsOf: parentModels)
                     processedModels.append(contentsOf: parentProcessedModels)
                     attributes.append(contentsOf: parentAttributes)
+                    inheritedTypes = inheritedTypes.union(parentInheritedTypes)
                     paths.append(contentsOf: parentPaths)
                     pathToContents.append(contentsOf:parentPathToContents)
                 }
@@ -79,7 +83,7 @@ func lookupEntities(key: String,
         paths.append(parentMock.filepath)
     }
     
-    return (models, processedModels, attributes, paths, pathToContents)
+    return (models, processedModels, attributes, inheritedTypes, paths, pathToContents)
 }
 
 

--- a/Sources/MockoloFramework/Utils/InheritanceResolver.swift
+++ b/Sources/MockoloFramework/Utils/InheritanceResolver.swift
@@ -49,7 +49,7 @@ func lookupEntities(key: String,
         if !current.isProcessed {
             attributes.append(contentsOf: sub.attributes)
         }
-        inheritedTypes = inheritedTypes.union(current.entityNode.inheritedTypes)
+        inheritedTypes.formUnion(current.entityNode.inheritedTypes)
         if let data = current.data {
             pathToContents.append((current.filepath, data, current.entityNode.offset))
         }
@@ -64,7 +64,7 @@ func lookupEntities(key: String,
                     models.append(contentsOf: parentModels)
                     processedModels.append(contentsOf: parentProcessedModels)
                     attributes.append(contentsOf: parentAttributes)
-                    inheritedTypes = inheritedTypes.union(parentInheritedTypes)
+                    inheritedTypes.formUnion(parentInheritedTypes)
                     paths.append(contentsOf: parentPaths)
                     pathToContents.append(contentsOf:parentPathToContents)
                 }

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -95,6 +95,8 @@ extension String {
     static let `escaping` = "@escaping"
     static let autoclosure = "@autoclosure"
     static let name = "name"
+    static let sendable = "Sendable"
+    static let uncheckedSendable = "@unchecked Sendable"
     static public let mockAnnotation = "@mockable"
     static public let mockObservable = "@MockObservable"
     static public let poundIf = "#if "

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -1,0 +1,94 @@
+import MockoloFramework
+
+let sendableProtocol = """
+import Foundation
+
+/// \(String.mockAnnotation)
+public protocol SendableProtocol: Sendable {
+    func update(arg: Int) -> String
+}
+"""
+
+let sendableProtocolMock = """
+
+import Foundation
+
+public class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
+    public init() { }
+
+
+    public private(set) var updateCallCount = 0
+    public var updateHandler: ((Int) -> (String))?
+    public func update(arg: Int) -> String {
+        updateCallCount += 1
+        if let updateHandler = updateHandler {
+            return updateHandler(arg)
+        }
+        return ""
+    }
+}
+
+"""
+
+let uncheckedSendableClass = """
+import Foundation
+
+/// \(String.mockAnnotation)
+public class UncheckedSendableClass: @unchecked Sendable {
+    func update(arg: Int) -> String
+}
+"""
+
+let uncheckedSendableClassMock = """
+
+import Foundation
+
+public class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {
+    public init() { }
+
+
+    private(set) var updateCallCount = 0
+    var updateHandler: ((Int) -> (String))?
+    override func update(arg: Int) -> String {
+        updateCallCount += 1
+        if let updateHandler = updateHandler {
+            return updateHandler(arg)
+        }
+        return ""
+    }
+}
+
+"""
+
+let confirmedSendableProtocol = """
+import Foundation
+
+public protocol SendableSendable: Sendable {
+    func update(arg: Int) -> String
+}
+
+/// \(String.mockAnnotation)
+public protocol ConfirmedSendableProtocol: SendableSendable {
+}
+"""
+
+let confirmedSendableProtocolMock = """
+
+import Foundation
+
+public class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
+    public init() { }
+
+
+    public private(set) var updateCallCount = 0
+    public var updateHandler: ((Int) -> (String))?
+    public func update(arg: Int) -> String {
+        updateCallCount += 1
+        if let updateHandler = updateHandler {
+            return updateHandler(arg)
+        }
+        return ""
+    }
+}
+
+"""

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -1,8 +1,6 @@
 import MockoloFramework
 
 let sendableProtocol = """
-import Foundation
-
 /// \(String.mockAnnotation)
 public protocol SendableProtocol: Sendable {
     func update(arg: Int) -> String
@@ -11,7 +9,7 @@ public protocol SendableProtocol: Sendable {
 
 let sendableProtocolMock = """
 
-import Foundation
+
 
 public class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
     public init() { }
@@ -31,8 +29,6 @@ public class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
 """
 
 let uncheckedSendableClass = """
-import Foundation
-
 /// \(String.mockAnnotation)
 public class UncheckedSendableClass: @unchecked Sendable {
     func update(arg: Int) -> String
@@ -41,7 +37,7 @@ public class UncheckedSendableClass: @unchecked Sendable {
 
 let uncheckedSendableClassMock = """
 
-import Foundation
+
 
 public class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {
     public init() { }
@@ -61,8 +57,6 @@ public class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Send
 """
 
 let confirmedSendableProtocol = """
-import Foundation
-
 public protocol SendableSendable: Sendable {
     func update(arg: Int) -> String
 }
@@ -74,7 +68,7 @@ public protocol ConfirmedSendableProtocol: SendableSendable {
 
 let confirmedSendableProtocolMock = """
 
-import Foundation
+
 
 public class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
     public init() { }

--- a/Tests/TestSendable/SendableTests.swift
+++ b/Tests/TestSendable/SendableTests.swift
@@ -1,6 +1,3 @@
-import Foundation
-
-
 class SendableTests: MockoloTestCase {
     func testSendableProtocol() {
         verify(srcContent: sendableProtocol,

--- a/Tests/TestSendable/SendableTests.swift
+++ b/Tests/TestSendable/SendableTests.swift
@@ -1,0 +1,20 @@
+import Foundation
+
+
+class SendableTests: MockoloTestCase {
+    func testSendableProtocol() {
+        verify(srcContent: sendableProtocol,
+               dstContent: sendableProtocolMock)
+    }
+
+    func testUncheckedSendableClass() {
+        verify(srcContent: uncheckedSendableClass,
+               dstContent: uncheckedSendableClassMock,
+               declType: .classType)
+    }
+
+    func testConfirmingSendableProtocol() {
+        verify(srcContent: confirmedSendableProtocol,
+               dstContent: confirmedSendableProtocolMock)
+    }
+}


### PR DESCRIPTION
# Summary
I have implemented the enhancements proposed in issue https://github.com/uber/mockolo/issues/252.

For mock classes that are required to conform to the `Sendable` protocol, I have made them inherit from `@unchecked Sendable`. This change should help reduce the number of unnecessary compiler warnings.

# Examples
```swift
Source

protocol SendableProtocol: Sendable {}
class UncheckedSendableClass: @unchecked Sendable {}
final class SendableClass: Sendable {}
```

```swift
Output

class SendableProtocolMock: SendableProtocol, @unchecked Sendable {}
class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {}
// final class SendableClass is skipped, because final class can't make a mock class.
```

# Previews
| Before | After |
| --- | --- |
| <img src="https://github.com/uber/mockolo/assets/40600280/4999535a-b3a4-4697-863d-e0c98c3475af" /> | <img src="https://github.com/uber/mockolo/assets/40600280/daa9be3d-8a5e-4d64-850a-0b1745ffeba8" /> |
