### PR TITLE
Add artifactbundle for build tools plugin

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -12,17 +12,11 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-12, macos-13, ubuntu-latest]
+        os: [macos-latest, ubuntu-latest]
     steps:
-      - uses: swift-actions/setup-swift@v1
-        if: runner.os == 'Linux'
-        with:
-          swift-version: "5.8"
       - name: Checkout
-        uses: actions/checkout@v3
-      - name: Build
-        run: swift build
-      - name: Test
-        run: swift test -c release
+        uses: actions/checkout@v4
+      - name: Build and Test
+        run: swift test
         env:
           CI: 1

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -129,6 +129,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4
+      with:
+        merge-multiple: true
     - name: Deploy the binary
       uses: softprops/action-gh-release@v2
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -100,9 +100,32 @@ jobs:
         docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work ${{ matrix.destination.tag }} \
           ./mockolo --version
 
+  make-artifact-bundle:
+    needs: [build, build-with-qemu]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Download all artifacts
+        uses: actions/download-artifact@v4
+      - run: bundle/make_artifactbundle.sh ${{ github.event.release.tag_name || github.ref_name }}
+
+      - name: Upload artifact bundle
+        uses: actions/upload-artifact@v4
+        with:
+          name: mockolo.artifactbundle.zip
+          path: mockolo.artifactbundle.zip
+
+      - name: Compute checksum
+        run: swift package compute-checksum mockolo.artifactbundle.zip > mockolo.artifactbundle.zip.checksum
+
+      - name: Upload checksum
+        uses: actions/upload-artifact@v4
+        with:
+          name: mockolo.artifactbundle.zip.checksum
+          path: mockolo.artifactbundle.zip.checksum
+
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
-    needs: [check-portability, check-portability-with-qemu]
+    needs: [check-portability, check-portability-with-qemu, make-artifact-bundle]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4
@@ -113,3 +136,5 @@ jobs:
           mockolo.ubuntu-x86_64.tar.gz
           mockolo.ubuntu-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
+          mockolo.artifactbundle.zip
+          mockolo.artifactbundle.zip.checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,14 +57,13 @@ jobs:
 
   check-portability:
     needs: build
-    name: TestRun on ${{ matrix.destination.os }}
+    name: TestRun on ${{ matrix.destination.os }} for ${{ matrix.destination.name }}
     runs-on: ${{ matrix.destination.os }}
     strategy:
       matrix:
         destination:
           - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
           - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
-          - { name: "ubuntu-aarch64", os: ubuntu-20.04, container: "arm64v8/ubuntu:latest" }
           - { name: "macos-universal", os: macos-14 }
           - { name: "macos-universal", os: macos-13 }
           - { name: "macos-universal", os: macos-12 }
@@ -80,7 +79,7 @@ jobs:
   check-portability-with-qemu:
     needs: build-with-qemu
     name: TestRun on ${{ matrix.destination.os }}
-    runs-on: ${{ matrix.destination.os }}
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         destination:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,6 +103,8 @@ jobs:
   make-artifact-bundle:
     needs: [build, build-with-qemu]
     runs-on: ubuntu-latest
+    outputs:
+      checksum: ${{ steps.checksum.outputs.checksum }}
     steps:
       - name: Download all artifacts
         uses: actions/download-artifact@v4
@@ -115,13 +117,8 @@ jobs:
           path: mockolo.artifactbundle.zip
 
       - name: Compute checksum
-        run: swift package compute-checksum mockolo.artifactbundle.zip > mockolo.artifactbundle.zip.checksum
-
-      - name: Upload checksum
-        uses: actions/upload-artifact@v4
-        with:
-          name: mockolo.artifactbundle.zip.checksum
-          path: mockolo.artifactbundle.zip.checksum
+        id: checksum
+        run: echo "checksum=$(swift package compute-checksum mockolo.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
 
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
@@ -132,9 +129,17 @@ jobs:
     - name: Deploy the binary
       uses: softprops/action-gh-release@v2
       with:
+        body: |
+          ```swift
+          .binaryTarget(
+            name: "mockolo",
+            url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo.artifactbundle.zip",
+            checksum: "${{ needs.make-artifact-bundle.outputs.checksum }}"
+          ),
+          ```
+        append_body: true
         files: |
           mockolo.ubuntu-x86_64.tar.gz
           mockolo.ubuntu-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
           mockolo.artifactbundle.zip
-          mockolo.artifactbundle.zip.checksum

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -109,8 +109,10 @@ jobs:
       - uses: actions/checkout@v4
       - name: Download all artifacts
         uses: actions/download-artifact@v4
-      - run: bundle/make_artifactbundle.sh ${{ github.event.release.tag_name || github.ref_name }}
+        with:
+          merge-multiple: true
 
+      - run: bundle/make_artifactbundle.sh ${{ github.event.release.tag_name || github.ref_name }}
       - name: Upload artifact bundle
         uses: actions/upload-artifact@v4
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,32 +5,58 @@ on:
   release:
     types: [published]
 
+env:
+  SWIFT_VERSION: "5.10"
+
 jobs:
-  build-release:
+  build:
     name: Build for ${{ matrix.destination.name }}
     runs-on: ${{ matrix.destination.os }}
     strategy:
       matrix:
         destination:
           - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
-          - { name: "ubuntu-aarch64", os: ubuntu-20.04, container: "arm64v8/ubuntu:latest" }
           - { name: "macos-universal", os: macos-12 }
     container: ${{ matrix.destination.container }}
     steps:
     - uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.10"
+        swift-version: ${{ env.SWIFT_VERSION }}
     - uses: actions/checkout@v4
     - name: Create the binary
-      run: ./install-script.sh -s . -t mockolo -d . -o mockolo.${{ matrix.destination.name }}.tar.gz
+      run: ./install-script.sh -s . -t mockolo -d . -o mockolo.tar.gz
     - name: Upload the binary
       uses: actions/upload-artifact@v4
       with:
+        path: mockolo.tar.gz
         name: mockolo.${{ matrix.destination.name }}
-        path: mockolo.${{ matrix.destination.name }}.tar.gz
+
+  build-with-qemu:
+    name: Build for${{ matrix.destination.name }}
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        destination:
+          - { name: "ubuntu-aarch64" }
+    steps:
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - uses: actions/checkout@v4
+      - name: Create the binary
+        run: |
+          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work swift:${{ env.SWIFT_VERSION }} \
+            ./install-script.sh -s . -t mockolo -d /work -o mockolo.tar.gz
+      - name: Upload the binary
+        uses: actions/upload-artifact@v4
+        with:
+          path: mockolo.tar.gz
+          name: mockolo.${{ matrix.destination.name }}
 
   check-portability:
-    needs: build-release
+    needs: build
     name: TestRun on ${{ matrix.destination.os }}
     runs-on: ${{ matrix.destination.os }}
     strategy:
@@ -51,9 +77,33 @@ jobs:
     - name: Run the binary
       run: ./mockolo --version
 
+  check-portability-with-qemu:
+    needs: build-with-qemu
+    name: TestRun on ${{ matrix.destination.os }}
+    runs-on: ${{ matrix.destination.os }}
+    strategy:
+      matrix:
+        destination:
+          - { name: "ubuntu-aarch64", tag: "ubuntu/latest" }
+    steps:
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v3
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - uses: actions/download-artifact@v4
+      with:
+        name: mockolo.${{ matrix.destination.name }}
+    - name: Unpack the binary
+      run: tar -xvf mockolo.${{ matrix.destination.name }}.tar.gz
+    - name: Run the binary
+      run: |
+        docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work ${{ matrix.destination.tag }} \
+          ./mockolo --version
+
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
-    needs: check-portability
+    needs: [check-portability, check-portability-with-qemu]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,7 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "ubuntu-aarch64", tag: "ubuntu/latest" }
+          - { name: "ubuntu-aarch64", tag: "ubuntu:latest" }
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -106,6 +106,7 @@ jobs:
     outputs:
       checksum: ${{ steps.checksum.outputs.checksum }}
     steps:
+      - uses: actions/checkout@v4
       - name: Download all artifacts
         uses: actions/download-artifact@v4
       - run: bundle/make_artifactbundle.sh ${{ github.event.release.tag_name || github.ref_name }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,7 +16,7 @@ jobs:
       matrix:
         destination:
           - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
-          - { name: "macos-universal", os: macos-12 }
+          - { name: "macos-universal", os: macos-14 }
     container: ${{ matrix.destination.container }}
     steps:
     - uses: swift-actions/setup-swift@v2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,6 +1,7 @@
 name: Release
 
 on:
+  workflow_dispatch:
   release:
     types: [published]
 
@@ -51,6 +52,7 @@ jobs:
       run: ./mockolo --version
 
   deploy-binary:
+    if: ${{ github.event_name == 'release' }}
     needs: check-portability
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,15 +24,15 @@ jobs:
         swift-version: ${{ env.SWIFT_VERSION }}
     - uses: actions/checkout@v4
     - name: Create the binary
-      run: ./install-script.sh -s . -t mockolo -d . -o mockolo.tar.gz
+      run: ./install-script.sh -s . -t mockolo -d . -o mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Upload the binary
       uses: actions/upload-artifact@v4
       with:
-        path: mockolo.tar.gz
+        path: mockolo.${{ matrix.destination.name }}.tar.gz
         name: mockolo.${{ matrix.destination.name }}
 
   build-with-qemu:
-    name: Build for${{ matrix.destination.name }}
+    name: Build for ${{ matrix.destination.name }}
     runs-on: ubuntu-latest
     strategy:
       matrix:
@@ -48,11 +48,11 @@ jobs:
       - name: Create the binary
         run: |
           docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work swift:${{ env.SWIFT_VERSION }} \
-            ./install-script.sh -s . -t mockolo -d /work -o mockolo.tar.gz
+            ./install-script.sh -s . -t mockolo -d /work -o mockolo.${{ matrix.destination.name }}.tar.gz
       - name: Upload the binary
         uses: actions/upload-artifact@v4
         with:
-          path: mockolo.tar.gz
+          path: mockolo.${{ matrix.destination.name }}.tar.gz
           name: mockolo.${{ matrix.destination.name }}
 
   check-portability:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,17 +11,19 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "ubuntu", os: ubuntu-20.04 }
-          - { name: "macos", os: macos-12 }
+          - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
+          - { name: "ubuntu-aarch64", os: ubuntu-20.04, container: "arm64v8/ubuntu:latest" }
+          - { name: "macos-universal", os: macos-12 }
+    container: ${{ matrix.destination.container }}
     steps:
-    - uses: swift-actions/setup-swift@v1
+    - uses: swift-actions/setup-swift@v2
       with:
-        swift-version: "5.8"
-    - uses: actions/checkout@v3
+        swift-version: "5.10"
+    - uses: actions/checkout@v4
     - name: Create the binary
       run: ./install-script.sh -s . -t mockolo -d . -o mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Upload the binary
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: mockolo.${{ matrix.destination.name }}
         path: mockolo.${{ matrix.destination.name }}.tar.gz
@@ -33,12 +35,14 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "ubuntu", os: ubuntu-22.04 }
-          - { name: "ubuntu", os: ubuntu-20.04 }
-          - { name: "macos", os: macos-12 }
-          - { name: "macos", os: macos-11 }
+          - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
+          - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
+          - { name: "ubuntu-aarch64", os: ubuntu-20.04, container: "arm64v8/ubuntu:latest" }
+          - { name: "macos-universal", os: macos-14 }
+          - { name: "macos-universal", os: macos-13 }
+          - { name: "macos-universal", os: macos-12 }
     steps:
-    - uses: actions/download-artifact@v3
+    - uses: actions/download-artifact@v4
       with:
         name: mockolo.${{ matrix.destination.name }}
     - name: Unpack the binary
@@ -50,15 +54,11 @@ jobs:
     needs: check-portability
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/download-artifact@v3
-      with:
-        name: mockolo.ubuntu
-    - uses: actions/download-artifact@v3
-      with:
-        name: mockolo.macos
+    - uses: actions/download-artifact@v4
     - name: Deploy the binary
-      uses: softprops/action-gh-release@v1
+      uses: softprops/action-gh-release@v2
       with:
         files: |
-          mockolo.ubuntu.tar.gz
-          mockolo.macos.tar.gz
+          mockolo.ubuntu-x86_64.tar.gz
+          mockolo.ubuntu-aarch64.tar.gz
+          mockolo.macos-universal.tar.gz

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -137,9 +137,9 @@ jobs:
         body: |
           ```swift
           .binaryTarget(
-            name: "mockolo",
-            url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo.artifactbundle.zip",
-            checksum: "${{ needs.make-artifact-bundle.outputs.checksum }}"
+              name: "mockolo",
+              url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo.artifactbundle.zip",
+              checksum: "${{ needs.make-artifact-bundle.outputs.checksum }}"
           ),
           ```
         append_body: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build-release:
-    name: Build on ${{ matrix.destination.os }}
+    name: Build for ${{ matrix.destination.name }}
     runs-on: ${{ matrix.destination.os }}
     strategy:
       matrix:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,7 +83,8 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "ubuntu-aarch64", tag: "ubuntu:latest" }
+          - { name: "ubuntu-aarch64", tag: "ubuntu:20.04" }
+          - { name: "ubuntu-aarch64", tag: "ubuntu:22.04" }
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/bundle/info.json
+++ b/bundle/info.json
@@ -1,0 +1,23 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "mockolo": {
+            "version": "__VERSION__",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "mockolo/macos/mockolo",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                },
+                {
+                    "path": "mockolo/ubuntu/x86_64-unknown-linux-gnu/mockolo",
+                    "supportedTriples": ["x86_64-unknown-linux-gnu"]
+                },
+                {
+                    "path": "mockolo/ubuntu/aarch64-unknown-linux-gnu/mockolo",
+                    "supportedTriples": ["aarch64-unknown-linux-gnu"]
+                }
+            ]
+        }
+    }
+}

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -12,14 +12,14 @@ if [ "$VERSION" = "" ]; then
     exit 1
 fi
 
-mkdir -p artifactbundle/mockolo/macos
-mkdir -p artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu
-mkdir -p artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/macos
+mkdir -p mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu
 
-tar -xzf mockolo.macos-universal.tar.gz -C artifactbundle/mockolo/macos/
-tar -xzf mockolo.ubuntu-x86_64.tar.gz -C artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu/
-tar -xzf mockolo.ubuntu-aarch64.tar.gz -C artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu/
+tar -xzf mockolo.macos-universal.tar.gz -C mockolo.artifactbundle/mockolo/macos/
+tar -xzf mockolo.ubuntu-x86_64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu/
+tar -xzf mockolo.ubuntu-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu/
 
-sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > artifactbundle/info.json
+sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > mockolo.artifactbundle/info.json
 
-zip -r ./mockolo.artifactbundle.zip ./artifactbundle
+zip -r ./mockolo.artifactbundle.zip ./mockolo.artifactbundle

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -1,0 +1,25 @@
+#!/bin/bash -e
+
+VERSION=$1
+
+usage() {
+    echo "[Usage] $0 <VERSION>"
+}
+
+if [ "$VERSION" = "" ]; then
+    usage
+    echo "VERSION is required"
+    exit 1
+fi
+
+mkdir -p artifactbundle/mockolo/macos
+mkdir -p artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu
+mkdir -p artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu
+
+tar -xzf mockolo.macos-universal.tar.gz -C artifactbundle/mockolo/macos/
+tar -xzf mockolo.ubuntu-x86_64.tar.gz -C artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu/
+tar -xzf mockolo.ubuntu-aarch64.tar.gz -C artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu/
+
+sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > artifactbundle/info.json
+
+zip -r ./mockolo.artifactbundle.zip ./artifactbundle

--- a/install-script.sh
+++ b/install-script.sh
@@ -9,7 +9,7 @@ Usage: -s/--source-dir [source dir], -t/--target [name of target to build/instal
     exit
 }
 
-if [[ $1 == "" ]] 
+if [[ $1 == "" ]]
 then
 showhelp
 fi
@@ -46,7 +46,7 @@ case $key in
     -h|--help)
     showhelp
     ;;
-    *) 
+    *)
     showhelp
     ;;
 esac
@@ -65,7 +65,7 @@ echo "OUTPUT FILE = ${OUTFILE}"
 cd "$SRCDIR"
 rm -rf .build
 case $(uname -s) in
-    Linux*)     swift build --static-swift-stdlib -c release --arch arm64 --arch x86_64
+    Linux*)     swift build --static-swift-stdlib -c release
                 cd .build/release;;
     Darwin*)    swift build -c release --arch arm64 --arch x86_64
                 cd .build/apple/Products/Release;;


### PR DESCRIPTION
Issue: https://github.com/uber/mockolo/issues/246

Add an artifact bundle to use as a build tools plugin.

This PR includes GitHub Actions to build for each architecture on Linux and macOS, and package them into an artifact bundle. Additionally, it documents the steps to use it as a build tools plugin in the README.md.