### PR TITLE
Fix release ci

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -47,7 +47,7 @@ jobs:
       - uses: actions/checkout@v4
       - name: Create the binary
         run: |
-          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work swift:${{ env.SWIFT_VERSION }} \
+          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work swift:${{ env.SWIFT_VERSION }}-focal \
             ./install-script.sh -s . -t mockolo -d /work -o mockolo.${{ matrix.destination.name }}.tar.gz
       - name: Upload the binary
         uses: actions/upload-artifact@v4
@@ -78,7 +78,7 @@ jobs:
 
   check-portability-with-qemu:
     needs: build-with-qemu
-    name: TestRun on ${{ matrix.destination.os }}
+    name: TestRun on ${{ matrix.destination.tag }}
     runs-on: ubuntu-latest
     strategy:
       matrix:

--- a/Sources/MockoloFramework/Version.swift
+++ b/Sources/MockoloFramework/Version.swift
@@ -3,5 +3,5 @@ public struct Version {
     public let value: String
 
     /// The current Mockolo version.
-    public static let current = Version(value: "2.1.0")
+    public static let current = Version(value: "2.1.1")
 }


### PR DESCRIPTION
Sorry, I have failed to release the latest version.
https://github.com/uber/mockolo/actions/runs/8795885150

No codebase changes, but I’m not sure about rerunning the release job on the `2.1.0` tag, so I suggest updating the patch version.

The updated job is tested at https://github.com/sidepelican/mockolo/actions/runs/8796562718 .