### PR TITLE
Compilation fix for a mock where the return type of a closure is an opaque type

### DIFF
--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -600,6 +600,9 @@ public final class `Type` {
         var ret = typeName
         if let closureRng = closureRng {
             let left = ret[ret.startIndex..<closureRng.lowerBound]
+            let right = ret[closureRng.lowerBound..<ret.endIndex]
+            ret = left + right.replacingOccurrences(of: String.some, with: String.any)
+            
             for item in typeParamList {
                 if isEscaping, left.literalComponents.contains(item) {
                     ret = String.anyType

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -601,7 +601,7 @@ public final class `Type` {
         if let closureRng = closureRng {
             let left = ret[ret.startIndex..<closureRng.lowerBound]
             let right = ret[closureRng.lowerBound..<ret.endIndex]
-            ret = left + right.replacingOccurrences(of: String.some, with: String.any)
+            ret = left + right.replacingOccurrences(of: "\(String.some) ", with: "\(String.any) ")
             
             for item in typeParamList {
                 if isEscaping, left.literalComponents.contains(item) {

--- a/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
+++ b/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
@@ -93,7 +93,7 @@ public class OpaqueTypeWithMultiTypeProtocolMock: OpaqueTypeWithMultiTypeProtoco
 let closureReturningSomeType = """
 /// \(String.mockAnnotation)
 protocol ProtocolReturningOpaqueTypeInClosureProtocol {
-    func register(router: @autoclosure @escaping () -> (some Error))
+    func register(router: @autoclosure @escaping () -> (some MyAwesomeType))
 }
 """
 
@@ -106,8 +106,8 @@ class ProtocolReturningOpaqueTypeInClosureProtocolMock: ProtocolReturningOpaqueT
 
 
     private(set) var registerCallCount = 0
-    var registerHandler: ((@autoclosure @escaping () -> (any Error)) -> ())?
-    func register(router: @autoclosure @escaping () -> (some Error))  {
+    var registerHandler: ((@autoclosure @escaping () -> (any MyAwesomeType)) -> ())?
+    func register(router: @autoclosure @escaping () -> (some MyAwesomeType))  {
         registerCallCount += 1
         if let registerHandler = registerHandler {
             registerHandler(router())

--- a/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
+++ b/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
@@ -89,3 +89,32 @@ public class OpaqueTypeWithMultiTypeProtocolMock: OpaqueTypeWithMultiTypeProtoco
 
 
 """
+
+let closureReturningSomeType = """
+/// \(String.mockAnnotation)
+protocol ProtocolReturningOpaqueTypeInClosureProtocol {
+    func register(router: @autoclosure @escaping () -> (some Error))
+}
+"""
+
+
+let closureReturningSomeTypeMock = """
+
+
+class ProtocolReturningOpaqueTypeInClosureProtocolMock: ProtocolReturningOpaqueTypeInClosureProtocol {
+    init() { }
+
+
+    private(set) var registerCallCount = 0
+    var registerHandler: ((@autoclosure @escaping () -> (any Error)) -> ())?
+    func register(router: @autoclosure @escaping () -> (some Error))  {
+        registerCallCount += 1
+        if let registerHandler = registerHandler {
+            registerHandler(router())
+        }
+
+    }
+}
+
+
+"""

--- a/Tests/TestFuncs/TestOpaqueTypeFuncs/OpaqueTypeFuncTests.swift
+++ b/Tests/TestFuncs/TestOpaqueTypeFuncs/OpaqueTypeFuncTests.swift
@@ -11,4 +11,9 @@ class OpaqueTypeFuncTests: MockoloTestCase {
         verify(srcContent: someMultiParameterOptionalType,
                dstContent: someMultiParameterOptionalTypeMock)
     }
+    
+    func testOpaqueTypeAsReturnTypeFuncs() {
+        verify(srcContent: closureReturningSomeType,
+               dstContent: closureReturningSomeTypeMock)
+    }
 }


### PR DESCRIPTION
The following code:

```
protocol ProtocolReturningOpaqueTypeInClosureProtocol {
    func register(router: @autoclosure @escaping () -> (some Error))
}
```

produces this mock:
```
class ProtocolReturningOpaqueTypeInClosureProtocolMock: ProtocolReturningOpaqueTypeInClosureProtocol {
    init() { }
    private(set) var registerCallCount = 0
    var registerHandler: ((@autoclosure @escaping () -> (some Error)) -> ())?
    func register(router: @autoclosure @escaping () -> (some Error))  {
        registerCallCount += 1
        if let registerHandler = registerHandler {
            registerHandler(router())
        }
    }
}
```

causing the compilation error:
`'some' cannot appear in parameter position in result type '((@autoclosure @escaping () -> (some Error)) -> ())?'`

This pr fixes the variable `registerHandler` by generating the following mock:
```
class ProtocolReturningOpaqueTypeInClosureProtocolMock: ProtocolReturningOpaqueTypeInClosureProtocol {
    init() { }
    private(set) var registerCallCount = 0
    var registerHandler: ((@autoclosure @escaping () -> (any Error)) -> ())?
    func register(router: @autoclosure @escaping () -> (some Error))  {
        registerCallCount += 1
        if let registerHandler = registerHandler {
            registerHandler(router())
        }
    }
}
```
