### PR TITLE
Added override for specifying the global actor of mocked async functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -424,6 +424,32 @@ This will generate:
 public class FooMock: FooProtocol { ... }
 ```
 
+To override the actor used for a mock's async functions:
+```swift
+/// @mockable(override: asyncFunctionGlobalActor = MainActor)
+public protocol FooProtocol {
+    func asyncFunction() async -> Bool
+}
+```
+
+This will generate:
+```swift
+public class FooProtocolMock: FooProtocol {
+    public init() { }
+
+
+    public private(set) var asyncFunctionCallCount = 0
+    public var asyncFunctionHandler: (() async -> (Bool))?
+    @MainActor public func asyncFunction() async -> Bool {
+        asyncFunctionCallCount += 1
+        if let asyncFunctionHandler = asyncFunctionHandler {
+            return await asyncFunctionHandler()
+        }
+        return false
+    }
+}
+```
+
 ## Used libraries
 
 [SwiftSyntax](https://github.com/apple/swift-syntax) |

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -30,7 +30,7 @@ final class MethodModel: Model {
     var offset: Int64
     let length: Int64
     let accessLevel: String
-    var attributes: [String]? = nil
+    let attribute: String
     let genericTypeParams: [ParamModel]
     var genericWhereClause: String? = nil
     let params: [ParamModel]
@@ -175,6 +175,7 @@ final class MethodModel: Model {
          funcsWithArgsHistory: [String],
          customModifiers: [String: Modifier],
          modelDescription: String?,
+         globalActorAttribute: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
         self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
@@ -192,6 +193,7 @@ final class MethodModel: Model {
         self.customModifiers = customModifiers
         self.modelDescription = modelDescription
         self.accessLevel = acl
+        self.attribute = globalActorAttribute.map { "@\($0)" } ?? ""
     }
 
     var fullName: String {
@@ -237,6 +239,7 @@ final class MethodModel: Model {
                                          params: params,
                                          returnType: type,
                                          accessLevel: accessLevel,
+                                         attribute: attribute,
                                          suffix: suffix,
                                          argsHistory: argsHistory,
                                          handler: handler(encloser: encloser))

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -124,6 +124,7 @@ public enum CombineType {
 /// e.g. @mockable(module: prefix = Foo; typealias: T = Any; U = String; rx: barStream = PublishSubject; history: bazFunc = true; modifiers: someVar = weak; combine: fooPublisher = CurrentValueSubject; otherPublisher = @Published otherProperty, override: name = FooMock)
 struct AnnotationMetadata {
     var nameOverride: String?
+    var asyncFunctionGlobalActorOverride: String?
     var module: String?
     var typeAliases: [String: String]?
     var varTypes: [String: String]?

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -31,6 +31,7 @@ extension MethodModel {
                              params: [ParamModel],
                              returnType: Type,
                              accessLevel: String,
+                             attribute: String,
                              suffix: String,
                              argsHistory: ArgumentsHistoryModel?,
                              handler: ClosureModel?) -> String {
@@ -39,6 +40,7 @@ extension MethodModel {
         let returnTypeName = returnType.isUnknown ? "" : returnType.typeName
 
         let acl = accessLevel.isEmpty ? "" : accessLevel+" "
+        let attribute = attribute.isEmpty ? "" : attribute+" "
         let genericTypeDeclsStr = genericTypeParams.compactMap {$0.render(with: "", encloser: "")}.joined(separator: ", ")
         let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
         var genericWhereStr = ""
@@ -148,7 +150,7 @@ extension MethodModel {
             template = """
             \(template)
             \(1.tab)\(acl)\(staticStr)var \(handlerVarName): \(handlerVarType)
-            \(1.tab)\(acl)\(staticStr)\(overrideStr)\(modifierTypeStr)\(keyword)\(name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnStr)\(genericWhereStr) {
+            \(1.tab)\(attribute)\(acl)\(staticStr)\(overrideStr)\(modifierTypeStr)\(keyword)\(name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnStr)\(genericWhereStr) {
             \(wrapped)
             \(1.tab)}
             """

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -95,6 +95,7 @@ extension String {
     static let `escaping` = "@escaping"
     static let autoclosure = "@autoclosure"
     static let name = "name"
+    static let asyncFunctionGlobalActor = "asyncFunctionGlobalActor"
     static let sendable = "Sendable"
     static let uncheckedSendable = "@unchecked Sendable"
     static public let mockAnnotation = "@mockable"

--- a/Tests/TestOverrides/AsyncFunctionGlobalActorOverrideTests.swift
+++ b/Tests/TestOverrides/AsyncFunctionGlobalActorOverrideTests.swift
@@ -1,0 +1,7 @@
+import Foundation
+
+class AsyncFunctionGlobalActorOverrideTests: MockoloTestCase {
+    func testAsyncFunctionGlobalActorOverride() {
+        verify(srcContent: asyncFunctionGlobalActorOverride, dstContent: asyncFunctionGlobalActorOverrideMock)
+    }
+}

--- a/Tests/TestOverrides/FixtureMockAsyncFunctionGlobalActors.swift
+++ b/Tests/TestOverrides/FixtureMockAsyncFunctionGlobalActors.swift
@@ -1,0 +1,38 @@
+import Foundation
+
+let asyncFunctionGlobalActorOverride =
+"""
+/// \(String.mockAnnotation)(override: asyncFunctionGlobalActor = MainActor)
+protocol FooProtocol {
+    func asyncFunction() async -> Bool
+    func syncFunction() -> Bool
+}
+"""
+
+let asyncFunctionGlobalActorOverrideMock =
+"""
+class FooProtocolMock: FooProtocol {
+    init() { }
+
+
+    private(set) var asyncFunctionCallCount = 0
+    var asyncFunctionHandler: (() async -> (Bool))?
+    @MainActor func asyncFunction() async -> Bool {
+        asyncFunctionCallCount += 1
+        if let asyncFunctionHandler = asyncFunctionHandler {
+            return await asyncFunctionHandler()
+        }
+        return false
+    }
+
+    private(set) var syncFunctionCallCount = 0
+    var syncFunctionHandler: (() -> (Bool))?
+    func syncFunction() -> Bool {
+        syncFunctionCallCount += 1
+        if let syncFunctionHandler = syncFunctionHandler {
+            return syncFunctionHandler()
+        }
+        return false
+    }
+}
+"""


### PR DESCRIPTION
 # Issue
#249  Async functions are unsafe in generated mocks, and can crash if used from multiple threads simultaneously

# Description
This change lets you specify the global actor that is used for your generated mock's async functions. This can be used to solve the problem described in #249 as when used there is no longer the chance for the async functions to be executed multiple times simultaneously.
I have allowed the user to specify the global actor so that they can choose to use a custom GlobalActor instead of assuming they always want to use the MainActor.