### PR TITLE
Speed up aarch64 builds using Static Linux SDK

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -54,7 +54,6 @@ jobs:
           - { name: "linux-x86_64", os: ubuntu-20.04 }
           - { name: "macos-universal", os: macos-14 }
           - { name: "macos-universal", os: macos-13 }
-          - { name: "macos-universal", os: macos-12 }
     steps:
     - uses: actions/download-artifact@v4
       with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,8 +38,8 @@ jobs:
     - name: Upload the binary
       uses: actions/upload-artifact@v4
       with:
+        name: mockolo.${{ matrix.destination.name }}.tar.gz
         path: mockolo.${{ matrix.destination.name }}.tar.gz
-        name: mockolo.${{ matrix.destination.name }}
 
   check-portability:
     needs: build
@@ -95,6 +95,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       checksum: ${{ steps.checksum.outputs.checksum }}
+      checksum-macos: ${{ steps.checksum-macos.outputs.checksum }}
     steps:
       - uses: actions/checkout@v4
       - name: Download all artifacts
@@ -108,10 +109,18 @@ jobs:
         with:
           name: mockolo.artifactbundle.zip
           path: mockolo.artifactbundle.zip
+      - name: Upload artifact bundle maocs
+        uses: actions/upload-artifact@v4
+        with:
+          name: mockolo-macos.artifactbundle.zip
+          path: mockolo-macos.artifactbundle.zip
 
       - name: Compute checksum
         id: checksum
         run: echo "checksum=$(swift package compute-checksum mockolo.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
+      - name: Compute checksum macos
+        id: checksum-macos
+        run: echo "checksum=$(swift package compute-checksum mockolo-macos.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
 
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
@@ -125,11 +134,27 @@ jobs:
       uses: softprops/action-gh-release@v2
       with:
         body: |
+          ----
+
+          ## For Build Tools Plugin (artifactbundle)
+
+          - full version (linux and macos)
+
           ```swift
           .binaryTarget(
               name: "mockolo",
               url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo.artifactbundle.zip",
               checksum: "${{ needs.make-artifact-bundle.outputs.checksum }}"
+          ),
+          ```
+
+          - lightweight version (macos only)
+
+          ```swift
+          .binaryTarget(
+              name: "mockolo",
+              url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo-macos.artifactbundle.zip",
+              checksum: "${{ needs.make-artifact-bundle.outputs.checksum-macos }}"
           ),
           ```
         append_body: true
@@ -138,3 +163,4 @@ jobs:
           mockolo.linux-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
           mockolo.artifactbundle.zip
+          mockolo-macos.artifactbundle.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -21,9 +21,13 @@ jobs:
           - { name: "linux-x86_64", os: ubuntu-latest }
           - { name: "macos-universal", os: macos-latest }
     steps:
-    - uses: vapor/swiftly-action@v0.1
+    - if: startsWith(matrix.destination.name, 'linux')
+      uses: vapor/swiftly-action@v0.1
       with:
         toolchain: ${{ env.SWIFT_VERSION }}
+    - if: startsWith(matrix.destination.name, 'macos')
+      run: sudo xcode-select -s /Applications/Xcode_16.app
+
     - if: startsWith(matrix.destination.name, 'linux')
       name: Install swift sdk
       run: swift sdk install ${{ env.SWIFT_SDK_URL }} --checksum ${{ env.SWIFT_SDK_CHECKSUM }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -46,11 +46,12 @@ jobs:
     name: TestRun on ${{ matrix.destination.os }} for ${{ matrix.destination.name }}
     runs-on: ${{ matrix.destination.os }}
     strategy:
+      fail-fast: false
       matrix:
         destination:
-          - { name: "ubuntu-x86_64", os: ubuntu-24.04 }
-          - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
-          - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
+          - { name: "linux-x86_64", os: ubuntu-24.04 }
+          - { name: "linux-x86_64", os: ubuntu-22.04 }
+          - { name: "linux-x86_64", os: ubuntu-20.04 }
           - { name: "macos-universal", os: macos-14 }
           - { name: "macos-universal", os: macos-13 }
           - { name: "macos-universal", os: macos-12 }
@@ -68,11 +69,12 @@ jobs:
     name: TestRun on ${{ matrix.destination.tag }}
     runs-on: ubuntu-latest
     strategy:
+      fail-fast: false
       matrix:
         destination:
-          - { name: "ubuntu-aarch64", tag: "ubuntu:20.04" }
-          - { name: "ubuntu-aarch64", tag: "ubuntu:22.04" }
-          - { name: "ubuntu-aarch64", tag: "ubuntu:24.04" }
+          - { name: "linux-aarch64", tag: "ubuntu:24.04" }
+          - { name: "linux-aarch64", tag: "ubuntu:22.04" }
+          - { name: "linux-aarch64", tag: "ubuntu:20.04" }
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,12 +25,11 @@ jobs:
       uses: vapor/swiftly-action@v0.1
       with:
         toolchain: ${{ env.SWIFT_VERSION }}
-    - if: startsWith(matrix.destination.name, 'macos')
-      run: sudo xcode-select -s /Applications/Xcode_16.app
-
     - if: startsWith(matrix.destination.name, 'linux')
       name: Install swift sdk
       run: swift sdk install ${{ env.SWIFT_SDK_URL }} --checksum ${{ env.SWIFT_SDK_CHECKSUM }}
+    - if: startsWith(matrix.destination.name, 'macos')
+      run: sudo xcode-select -s /Applications/Xcode_16.app
 
     - uses: actions/checkout@v4
     - name: Create the binary

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,9 @@ on:
     types: [published]
 
 env:
-  SWIFT_VERSION: "5.10"
+  SWIFT_VERSION: "6.0"
+  SWIFT_SDK_URL: https://download.swift.org/swift-6.0.1-release/static-sdk/swift-6.0.1-RELEASE/swift-6.0.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
+  SWIFT_SDK_CHECKSUM: d4f46ba40e11e697387468e18987ee622908bc350310d8af54eb5e17c2ff5481
 
 jobs:
   build:
@@ -15,13 +17,17 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
-          - { name: "macos-universal", os: macos-14 }
-    container: ${{ matrix.destination.container }}
+          - { name: "linux-aarch64", os: ubuntu-latest }
+          - { name: "linux-x86_64", os: ubuntu-latest }
+          - { name: "macos-universal", os: macos-latest }
     steps:
-    - uses: swift-actions/setup-swift@v2
+    - uses: vapor/swiftly-action@v0.1
       with:
-        swift-version: ${{ env.SWIFT_VERSION }}
+        toolchain: ${{ env.SWIFT_VERSION }}
+    - if: startsWith(matrix.destination.name, 'linux')
+      name: Install swift sdk
+      run: swift sdk install ${{ env.SWIFT_SDK_URL }} --checksum ${{ env.SWIFT_SDK_CHECKSUM }}
+
     - uses: actions/checkout@v4
     - name: Create the binary
       run: ./install-script.sh -s . -t mockolo -d . -o mockolo.${{ matrix.destination.name }}.tar.gz
@@ -31,30 +37,6 @@ jobs:
         path: mockolo.${{ matrix.destination.name }}.tar.gz
         name: mockolo.${{ matrix.destination.name }}
 
-  build-with-qemu:
-    name: Build for ${{ matrix.destination.name }}
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        destination:
-          - { name: "ubuntu-aarch64" }
-    steps:
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-
-      - uses: actions/checkout@v4
-      - name: Create the binary
-        run: |
-          docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work swift:${{ env.SWIFT_VERSION }}-focal \
-            ./install-script.sh -s . -t mockolo -d /work -o mockolo.${{ matrix.destination.name }}.tar.gz
-      - name: Upload the binary
-        uses: actions/upload-artifact@v4
-        with:
-          path: mockolo.${{ matrix.destination.name }}.tar.gz
-          name: mockolo.${{ matrix.destination.name }}
-
   check-portability:
     needs: build
     name: TestRun on ${{ matrix.destination.os }} for ${{ matrix.destination.name }}
@@ -62,6 +44,7 @@ jobs:
     strategy:
       matrix:
         destination:
+          - { name: "ubuntu-x86_64", os: ubuntu-24.04 }
           - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
           - { name: "ubuntu-x86_64", os: ubuntu-20.04 }
           - { name: "macos-universal", os: macos-14 }
@@ -77,7 +60,7 @@ jobs:
       run: ./mockolo --version
 
   check-portability-with-qemu:
-    needs: build-with-qemu
+    needs: build
     name: TestRun on ${{ matrix.destination.tag }}
     runs-on: ubuntu-latest
     strategy:
@@ -85,6 +68,7 @@ jobs:
         destination:
           - { name: "ubuntu-aarch64", tag: "ubuntu:20.04" }
           - { name: "ubuntu-aarch64", tag: "ubuntu:22.04" }
+          - { name: "ubuntu-aarch64", tag: "ubuntu:24.04" }
     steps:
     - name: Set up QEMU
       uses: docker/setup-qemu-action@v3
@@ -102,7 +86,7 @@ jobs:
           ./mockolo --version
 
   make-artifact-bundle:
-    needs: [build, build-with-qemu]
+    needs: [build]
     runs-on: ubuntu-latest
     outputs:
       checksum: ${{ steps.checksum.outputs.checksum }}
@@ -145,7 +129,7 @@ jobs:
           ```
         append_body: true
         files: |
-          mockolo.ubuntu-x86_64.tar.gz
-          mockolo.ubuntu-aarch64.tar.gz
+          mockolo.linux-x86_64.tar.gz
+          mockolo.linux-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
           mockolo.artifactbundle.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,7 @@ jobs:
     steps:
     - uses: actions/download-artifact@v4
       with:
-        name: mockolo.${{ matrix.destination.name }}
+        name: mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Unpack the binary
       run: tar -xvf mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Run the binary
@@ -82,7 +82,7 @@ jobs:
 
     - uses: actions/download-artifact@v4
       with:
-        name: mockolo.${{ matrix.destination.name }}
+        name: mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Unpack the binary
       run: tar -xvf mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Run the binary

--- a/bundle/info-macos.json
+++ b/bundle/info-macos.json
@@ -1,0 +1,15 @@
+{
+    "schemaVersion": "1.0",
+    "artifacts": {
+        "mockolo": {
+            "version": "__VERSION__",
+            "type": "executable",
+            "variants": [
+                {
+                    "path": "mockolo/macos/mockolo",
+                    "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
+                }
+            ]
+        }
+    }
+}

--- a/bundle/info.json
+++ b/bundle/info.json
@@ -10,11 +10,11 @@
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 },
                 {
-                    "path": "mockolo/ubuntu/x86_64-unknown-linux-gnu/mockolo",
+                    "path": "mockolo/linux/x86_64-unknown-linux-gnu/mockolo",
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
                 },
                 {
-                    "path": "mockolo/ubuntu/aarch64-unknown-linux-gnu/mockolo",
+                    "path": "mockolo/linux/aarch64-unknown-linux-gnu/mockolo",
                     "supportedTriples": ["aarch64-unknown-linux-gnu"]
                 }
             ]

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -13,12 +13,12 @@ if [ "$VERSION" = "" ]; then
 fi
 
 mkdir -p mockolo.artifactbundle/mockolo/macos
-mkdir -p mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu
-mkdir -p mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/linux/x86_64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/linux/aarch64-unknown-linux-gnu
 
 tar -xzf mockolo.macos-universal.tar.gz -C mockolo.artifactbundle/mockolo/macos/
-tar -xzf mockolo.ubuntu-x86_64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu/
-tar -xzf mockolo.ubuntu-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu/
+tar -xzf mockolo.linux-x86_64.tar.gz -C mockolo.artifactbundle/mockolo/linux/x86_64-unknown-linux-gnu/
+tar -xzf mockolo.linux-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/linux/aarch64-unknown-linux-gnu/
 
 sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > mockolo.artifactbundle/info.json
 

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -12,6 +12,7 @@ if [ "$VERSION" = "" ]; then
     exit 1
 fi
 
+# Archive universal artifacts
 mkdir -p mockolo.artifactbundle/mockolo/macos
 mkdir -p mockolo.artifactbundle/mockolo/linux/x86_64-unknown-linux-gnu
 mkdir -p mockolo.artifactbundle/mockolo/linux/aarch64-unknown-linux-gnu
@@ -23,3 +24,12 @@ tar -xzf mockolo.linux-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/linux/aa
 sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > mockolo.artifactbundle/info.json
 
 zip -r ./mockolo.artifactbundle.zip ./mockolo.artifactbundle
+
+# Archive macOS artifacts
+mkdir -p mockolo-macos.artifactbundle/mockolo/macos
+
+tar -xzf mockolo.macos-universal.tar.gz -C mockolo-macos.artifactbundle/mockolo/macos/
+
+sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info-macos.json > mockolo-macos.artifactbundle/info.json
+
+zip -r ./mockolo-macos.artifactbundle.zip ./mockolo-macos.artifactbundle

--- a/install-script.sh
+++ b/install-script.sh
@@ -65,7 +65,7 @@ echo "OUTPUT FILE = ${OUTFILE}"
 cd "$SRCDIR"
 rm -rf .build
 case $(uname -s) in
-    Linux*)     swift build --static-swift-stdlib -c release
+    Linux*)     swift build -c release --swift-sdk $(uname -p)-swift-linux-musl
                 cd .build/release;;
     Darwin*)    swift build -c release --arch arm64 --arch x86_64
                 cd .build/apple/Products/Release;;


### PR DESCRIPTION
## Motivation

Currently, the mockolo binary for aarch64 on Ubuntu is built on an x86_64 machine using Docker and qemu, which is extremely slow.
With the release of [Static Linux SDK](https://www.swift.org/documentation/articles/static-linux-getting-started.html) in Swift 6, we can speed up the build process for aarch64 Linux.

## Changes

In the GitHub Actions for the release build, we install the Static Linux SDK and use it. 
As a result, the size of the artifact bundle has increased. To address this, we provide a lightweight artifact bundle without Linux support for users who only use mockolo on macOS.

## Misc

Since the Static Linux SDK uses musl, mockolo will be able to run on more Linux distributions. However, we do not have a strong motivation to actively support these additional distributions, so this is more of a bonus.