### PR TITLE
Add support for `Actor` protocol.

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -10,7 +10,7 @@ final class ArgumentsHistoryModel: Model {
     let isHistoryAnnotated: Bool
 
     var modelType: ModelType {
-        return .class
+        return .argumentsHistory
     }
 
     init?(name: String, genericTypeParams: [ParamModel], params: [ParamModel], isHistoryAnnotated: Bool, suffix: String) {

--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -2,11 +2,11 @@ import Foundation
 
 final class ArgumentsHistoryModel: Model {
     var name: String
-    var type: Type
+    var type: SwiftType
     var offset: Int64 = .max
     let suffix: String
     let capturableParamNames: [String]
-    let capturableParamTypes: [Type]
+    let capturableParamTypes: [SwiftType]
     let isHistoryAnnotated: Bool
 
     var modelType: ModelType {
@@ -28,7 +28,7 @@ final class ArgumentsHistoryModel: Model {
         self.capturableParamTypes = capturables.map(\.type)
         
         let genericTypeNameList = genericTypeParams.map(\.name)
-        self.type = Type.toArgumentsHistoryType(with: capturableParamTypes, typeParams: genericTypeNameList)
+        self.type = SwiftType.toArgumentsHistoryType(with: capturableParamTypes, typeParams: genericTypeNameList)
     }
     
     func enable(force: Bool) -> Bool {

--- a/Sources/MockoloFramework/Models/ClassModel.swift
+++ b/Sources/MockoloFramework/Models/ClassModel.swift
@@ -19,7 +19,7 @@ import Foundation
 final class ClassModel: Model {
     var name: String
     var offset: Int64
-    var type: Type
+    var type: SwiftType
     let attribute: String
     let accessLevel: String
     let identifier: String
@@ -46,7 +46,7 @@ final class ClassModel: Model {
          entities: [(String, Model)]) {
         self.identifier = identifier 
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
-        self.type = Type(.class)
+        self.type = SwiftType(.class)
         self.declType = declType
         self.inheritedTypes = inheritedTypes
         self.entities = entities

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -27,7 +27,7 @@ final class ClosureModel: Model {
     let suffix: String
 
     var modelType: ModelType {
-        return .class
+        return .closure
     }
 
     

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -18,12 +18,12 @@ import Foundation
 
 final class ClosureModel: Model {
     var name: String
-    var type: Type
+    var type: SwiftType
     var offset: Int64 = .max
-    let funcReturnType: Type
+    let funcReturnType: SwiftType
     let genericTypeNames: [String]
     let paramNames: [String]
-    let paramTypes: [Type]
+    let paramTypes: [SwiftType]
     let suffix: String
 
     var modelType: ModelType {
@@ -31,7 +31,7 @@ final class ClosureModel: Model {
     }
 
     
-    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [Type], suffix: String, returnType: Type, encloser: String) {
+    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [SwiftType], suffix: String, returnType: SwiftType, encloser: String) {
         self.name = name + .handlerSuffix
         self.suffix = suffix
         let genericTypeNameList = genericTypeParams.map(\.name)
@@ -39,7 +39,7 @@ final class ClosureModel: Model {
         self.paramNames = paramNames
         self.paramTypes = paramTypes
         self.funcReturnType = returnType
-        self.type = Type.toClosureType(with: paramTypes, typeParams: genericTypeNameList, suffix: suffix, returnType: returnType, encloser: encloser)
+        self.type = SwiftType.toClosureType(with: paramTypes, typeParams: genericTypeNameList, suffix: suffix, returnType: returnType, encloser: encloser)
     }
     
     func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {

--- a/Sources/MockoloFramework/Models/IfMacroModel.swift
+++ b/Sources/MockoloFramework/Models/IfMacroModel.swift
@@ -19,7 +19,7 @@ import Foundation
 final class IfMacroModel: Model {
     var name: String
     var offset: Int64
-    var type: Type
+    var type: SwiftType
     let entities: [Model]
     
     var modelType: ModelType {
@@ -36,7 +36,7 @@ final class IfMacroModel: Model {
         self.name = name
         self.entities = entities
         self.offset = offset
-        self.type = Type(name)
+        self.type = SwiftType(name)
     }
     
     func render(with identifier: String, encloser: String, useTemplateFunc: Bool, useMockObservable: Bool, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -26,7 +26,7 @@ final class MethodModel: Model {
     var filePath: String = ""
     var data: Data? = nil
     var name: String
-    var type: Type
+    var type: SwiftType
     var offset: Int64
     let length: Int64
     let accessLevel: String
@@ -177,7 +177,7 @@ final class MethodModel: Model {
          modelDescription: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
+        self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
         self.suffix = [asyncOrReasync, throwsOrRethrows].compactMap { $0 }.joined(separator: " ")
         self.offset = offset
         self.length = length

--- a/Sources/MockoloFramework/Models/Model.swift
+++ b/Sources/MockoloFramework/Models/Model.swift
@@ -42,7 +42,7 @@ public protocol Model {
     var isStatic: Bool { get }
 
     /// Decl(e.g. class/struct/protocol/enum) or return type (e.g. var/func)
-    var type: Type { get set }
+    var type: SwiftType { get set }
 
     /// Offset where this type is declared
     var offset: Int64 { get set }

--- a/Sources/MockoloFramework/Models/Model.swift
+++ b/Sources/MockoloFramework/Models/Model.swift
@@ -17,7 +17,14 @@
 import Foundation
 
 public enum ModelType {
-    case variable, method, typeAlias, parameter, macro, `class`
+    case variable
+    case method
+    case typeAlias
+    case parameter
+    case macro
+    case nominal
+    case argumentsHistory
+    case closure
 }
 
 /// Represents a model for an entity such as var, func, class, etc.

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-final class ClassModel: Model {
+final class NominalModel: Model {
     var name: String
     var offset: Int64
     var type: SwiftType
@@ -31,7 +31,7 @@ final class ClassModel: Model {
     let metadata: AnnotationMetadata?
 
     var modelType: ModelType {
-        return .class
+        return .nominal
     }
     
     init(identifier: String,

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -17,27 +17,33 @@
 import Foundation
 
 final class NominalModel: Model {
+    enum NominalTypeDeclKind: String {
+        case `class`
+        case `actor`
+    }
+
     var name: String
     var offset: Int64
     var type: SwiftType
     let attribute: String
     let accessLevel: String
     let identifier: String
-    let declType: DeclType
+    let declTypeOfMockAnnotatedBaseType: DeclType
     let inheritedTypes: [String]
     let entities: [(String, Model)]
     let initParamCandidates: [VariableModel]
     let declaredInits: [MethodModel]
     let metadata: AnnotationMetadata?
+    let declKind: NominalTypeDeclKind
 
     var modelType: ModelType {
         return .nominal
     }
     
     init(identifier: String,
-         type: SwiftType,
          acl: String,
-         declType: DeclType,
+         declTypeOfMockAnnotatedBaseType: DeclType,
+         declKind: NominalTypeDeclKind,
          inheritedTypes: [String],
          attributes: [String],
          offset: Int64,
@@ -47,8 +53,9 @@ final class NominalModel: Model {
          entities: [(String, Model)]) {
         self.identifier = identifier 
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
-        self.type = type
-        self.declType = declType
+        self.type = SwiftType(self.name)
+        self.declTypeOfMockAnnotatedBaseType = declTypeOfMockAnnotatedBaseType
+        self.declKind = declKind
         self.inheritedTypes = inheritedTypes
         self.entities = entities
         self.declaredInits = declaredInits
@@ -74,7 +81,7 @@ final class NominalModel: Model {
             identifier: self.identifier,
             accessLevel: accessLevel,
             attribute: attribute,
-            declType: declType,
+            declTypeOfMockAnnotatedBaseType: declTypeOfMockAnnotatedBaseType,
             inheritedTypes: inheritedTypes,
             metadata: metadata,
             useTemplateFunc: useTemplateFunc,

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -35,6 +35,7 @@ final class NominalModel: Model {
     }
     
     init(identifier: String,
+         type: SwiftType,
          acl: String,
          declType: DeclType,
          inheritedTypes: [String],
@@ -46,7 +47,7 @@ final class NominalModel: Model {
          entities: [(String, Model)]) {
         self.identifier = identifier 
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
-        self.type = SwiftType(.class)
+        self.type = type
         self.declType = declType
         self.inheritedTypes = inheritedTypes
         self.entities = entities
@@ -68,7 +69,7 @@ final class NominalModel: Model {
         enableFuncArgsHistory: Bool = false,
         disableCombineDefaultValues: Bool = false
     ) -> String? {
-        return applyClassTemplate(
+        return applyNominalTemplate(
             name: name,
             identifier: self.identifier,
             accessLevel: accessLevel,

--- a/Sources/MockoloFramework/Models/ParamModel.swift
+++ b/Sources/MockoloFramework/Models/ParamModel.swift
@@ -20,7 +20,7 @@ final class ParamModel: Model {
     var name: String
     var offset: Int64
     var length: Int64
-    var type: Type
+    var type: SwiftType
     let label: String
     let isGeneric: Bool
     let inInit: Bool
@@ -40,7 +40,7 @@ final class ParamModel: Model {
     
     init(label: String = "", name: String, typeName: String, isGeneric: Bool = false, inInit: Bool = false, needVarDecl: Bool, offset: Int64, length: Int64) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
+        self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
         let labelStr = label.trimmingCharacters(in: .whitespaces)
         self.label = name != labelStr ? labelStr : ""
         self.offset = offset
@@ -77,9 +77,9 @@ final class ParamModel: Model {
     /// ```
     func asInitVarDecl(eraseType: Bool) -> String? {
         if self.inInit, self.needVarDecl {
-            let type: `Type`
+            let type: SwiftType
             if eraseType {
-                type = Type(.anyType)
+                type = SwiftType(.anyType)
             } else {
                 type = self.type
             }

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -23,6 +23,7 @@ struct ResolvedEntity {
     let uniqueModels: [(String, Model)]
     let attributes: [String]
     let inheritedTypes: [String]
+    var inheritsActorProtocol: Bool
 
     var declaredInits: [MethodModel] {
         return uniqueModels.filter {$0.1.isInitializer}.compactMap{ $0.1 as? MethodModel }
@@ -63,15 +64,16 @@ struct ResolvedEntity {
 
     func model() -> Model {
         return NominalModel(identifier: key,
-                          acl: entity.entityNode.accessLevel,
-                          declType: entity.entityNode.declType,
-                          inheritedTypes: inheritedTypes,
-                          attributes: attributes,
-                          offset: entity.entityNode.offset,
-                          metadata: entity.metadata,
-                          initParamCandidates: initParamCandidates,
-                          declaredInits: declaredInits,
-                          entities: uniqueModels)
+                            type: SwiftType(inheritsActorProtocol ? .actor : .class),
+                            acl: entity.entityNode.accessLevel,
+                            declType: entity.entityNode.declType,
+                            inheritedTypes: inheritedTypes,
+                            attributes: attributes,
+                            offset: entity.entityNode.offset,
+                            metadata: entity.metadata,
+                            initParamCandidates: initParamCandidates,
+                            declaredInits: declaredInits,
+                            entities: uniqueModels)
     }
 }
 

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -64,9 +64,9 @@ struct ResolvedEntity {
 
     func model() -> Model {
         return NominalModel(identifier: key,
-                            type: SwiftType(inheritsActorProtocol ? .actor : .class),
                             acl: entity.entityNode.accessLevel,
-                            declType: entity.entityNode.declType,
+                            declTypeOfMockAnnotatedBaseType: entity.entityNode.declType,
+                            declKind: inheritsActorProtocol ? .actor : .class,
                             inheritedTypes: inheritedTypes,
                             attributes: attributes,
                             offset: entity.entityNode.offset,

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -62,7 +62,7 @@ struct ResolvedEntity {
 
 
     func model() -> Model {
-        return ClassModel(identifier: key,
+        return NominalModel(identifier: key,
                           acl: entity.entityNode.accessLevel,
                           declType: entity.entityNode.declType,
                           inheritedTypes: inheritedTypes,

--- a/Sources/MockoloFramework/Models/TypeAliasModel.swift
+++ b/Sources/MockoloFramework/Models/TypeAliasModel.swift
@@ -19,7 +19,7 @@ import Foundation
 final class TypeAliasModel: Model {
     var filePath: String = ""
     var name: String
-    var type: Type
+    var type: SwiftType
     var offset: Int64 = .max
     var length: Int64
     var typeOffset: Int64 = 0
@@ -47,9 +47,9 @@ final class TypeAliasModel: Model {
         self.addAcl = encloserType == .protocolType && !processed
         // If there's an override typealias value, set it to type
         if let val = overrideTypes?[self.name] {
-            self.type  = Type(val)
+            self.type  = SwiftType(val)
         } else {
-            self.type = typeName.isEmpty ? Type(String.anyType) : Type(typeName)
+            self.type = typeName.isEmpty ? SwiftType(String.anyType) : SwiftType(typeName)
         }
     }
 

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -2,7 +2,7 @@ import Foundation
 
 final class VariableModel: Model {
     var name: String
-    var type: Type
+    var type: SwiftType
     var offset: Int64
     let accessLevel: String
     let attributes: [String]?
@@ -48,7 +48,7 @@ final class VariableModel: Model {
          combineType: CombineType?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.type = Type(typeName.trimmingCharacters(in: .whitespaces))
+        self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
         self.offset = offset
         self.isStatic = isStatic
         self.shouldOverride = encloserType == .classType

--- a/Sources/MockoloFramework/Operations/Generator.swift
+++ b/Sources/MockoloFramework/Operations/Generator.swift
@@ -112,7 +112,7 @@ public func generate(sourceDirs: [String],
     typeKeyList.forEach { (t: String) in
         typeKeys[t] = "\(t)Mock()"
     }
-    Type.customTypeMap = typeKeys
+    SwiftType.customTypeMap = typeKeys
 
     signpost_begin(name: "Generate models")
     log("Resolve inheritance and generate unique entity models...", level: .info)

--- a/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
+++ b/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
@@ -71,7 +71,14 @@ private func generateUniqueModels(key: String,
         mockInheritedTypes.append(.uncheckedSendable)
     }
 
-    let resolvedEntity = ResolvedEntity(key: key, entity: entity, uniqueModels: uniqueModels, attributes: attributes, inheritedTypes: mockInheritedTypes)
+    let resolvedEntity = ResolvedEntity(
+        key: key,
+        entity: entity,
+        uniqueModels: uniqueModels,
+        attributes: attributes,
+        inheritedTypes: mockInheritedTypes,
+        inheritsActorProtocol: inheritedTypes.contains(.actorProtocol)
+    )
 
     return ResolvedEntityContainer(entity: resolvedEntity, paths: paths, imports: pathToContentList)
 }

--- a/Sources/MockoloFramework/Templates/ClassTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClassTemplate.swift
@@ -16,7 +16,7 @@
 
 import Foundation
 
-extension ClassModel {
+extension NominalModel {
     func applyClassTemplate(name: String,
                             identifier: String,
                             accessLevel: String,

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -18,12 +18,12 @@ import Foundation
 
 extension ClosureModel {
     func applyClosureTemplate(name: String,
-                              type: Type,
+                              type: SwiftType,
                               genericTypeNames: [String],
                               paramVals: [String]?,
-                              paramTypes: [Type]?,
+                              paramTypes: [SwiftType]?,
                               suffix: String,
-                              returnDefaultType: Type) -> String {
+                              returnDefaultType: SwiftType) -> String {
         
         var handlerParamValsStr = ""
         if let paramVals = paramVals, let paramTypes = paramTypes {
@@ -64,7 +64,7 @@ extension ClosureModel {
     }
     
     
-    private func renderReturnDefaultStatement(name: String, type: Type) -> String {
+    private func renderReturnDefaultStatement(name: String, type: SwiftType) -> String {
         guard !type.isUnknown else { return "" }
         
         let result = type.defaultVal() ?? String.fatalError
@@ -79,7 +79,7 @@ extension ClosureModel {
     }
 
     private func renderOptionalGenericClosure(
-        argType: Type,
+        argType: SwiftType,
         argName: String
     ) -> String? {
         let literalComponents = argType.typeName.literalComponents

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -29,7 +29,7 @@ extension MethodModel {
                              genericTypeParams: [ParamModel],
                              genericWhereClause: String?,
                              params: [ParamModel],
-                             returnType: Type,
+                             returnType: SwiftType,
                              accessLevel: String,
                              suffix: String,
                              argsHistory: ArgumentsHistoryModel?,

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -17,22 +17,22 @@
 import Foundation
 
 extension NominalModel {
-    func applyClassTemplate(name: String,
-                            identifier: String,
-                            accessLevel: String,
-                            attribute: String,
-                            declType: DeclType,
-                            inheritedTypes: [String],
-                            metadata: AnnotationMetadata?,
-                            useTemplateFunc: Bool,
-                            useMockObservable: Bool,
-                            allowSetCallCount: Bool,
-                            mockFinal: Bool,
-                            enableFuncArgsHistory: Bool,
-                            disableCombineDefaultValues: Bool,
-                            initParamCandidates: [VariableModel],
-                            declaredInits: [MethodModel],
-                            entities: [(String, Model)]) -> String {
+    func applyNominalTemplate(name: String,
+                              identifier: String,
+                              accessLevel: String,
+                              attribute: String,
+                              declType: DeclType,
+                              inheritedTypes: [String],
+                              metadata: AnnotationMetadata?,
+                              useTemplateFunc: Bool,
+                              useMockObservable: Bool,
+                              allowSetCallCount: Bool,
+                              mockFinal: Bool,
+                              enableFuncArgsHistory: Bool,
+                              disableCombineDefaultValues: Bool,
+                              initParamCandidates: [VariableModel],
+                              declaredInits: [MethodModel],
+                              entities: [(String, Model)]) -> String {
 
         processCombineAliases(entities: entities)
         
@@ -97,7 +97,7 @@ extension NominalModel {
         let finalStr = mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)class \(name): \(inheritedTypes.joined(separator: ", ")) {
+        \(acl)\(finalStr)\(type.typeName) \(name): \(inheritedTypes.joined(separator: ", ")) {
         \(body)
         }
         """

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -21,7 +21,7 @@ extension NominalModel {
                               identifier: String,
                               accessLevel: String,
                               attribute: String,
-                              declType: DeclType,
+                              declTypeOfMockAnnotatedBaseType: DeclType,
                               inheritedTypes: [String],
                               metadata: AnnotationMetadata?,
                               useTemplateFunc: Bool,
@@ -65,7 +65,7 @@ extension NominalModel {
         .joined(separator: "\n")
         
         var typealiasTemplate = ""
-        let addAcl = declType == .protocolType ? acl : ""
+        let addAcl = declTypeOfMockAnnotatedBaseType == .protocolType ? acl : ""
         if let typealiasWhitelist = typealiases {
             typealiasTemplate = typealiasWhitelist.map { (arg: (key: String, value: [String])) -> String in
                 let joinedType = arg.value.sorted().joined(separator: " & ")
@@ -78,7 +78,7 @@ extension NominalModel {
             moduleDot = moduleName + "."
         }
         
-        let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits,  acl: acl, declType: declType, overrides: metadata?.varTypes)
+        let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits,  acl: acl, declTypeOfMockAnnotatedBaseType: declTypeOfMockAnnotatedBaseType, overrides: metadata?.varTypes)
 
         var inheritedTypes = inheritedTypes
         inheritedTypes.insert("\(moduleDot)\(identifier)", at: 0)
@@ -97,7 +97,7 @@ extension NominalModel {
         let finalStr = mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)\(type.typeName) \(name): \(inheritedTypes.joined(separator: ", ")) {
+        \(acl)\(finalStr)\(declKind.rawValue) \(name): \(inheritedTypes.joined(separator: ", ")) {
         \(body)
         }
         """
@@ -109,7 +109,7 @@ extension NominalModel {
         initParamCandidates: [VariableModel],
         declaredInits: [MethodModel],
         acl: String,
-        declType: DeclType,
+        declTypeOfMockAnnotatedBaseType: DeclType,
         overrides: [String: String]?
     ) -> String {
         
@@ -122,7 +122,7 @@ extension NominalModel {
             needBlankInit = true
             needParamedInit = false
         } else {
-            if declType == .protocolType {
+            if declTypeOfMockAnnotatedBaseType == .protocolType {
                 needParamedInit = !initParamCandidates.isEmpty
                 needBlankInit = true
 

--- a/Sources/MockoloFramework/Templates/ParamTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ParamTemplate.swift
@@ -19,7 +19,7 @@ import Foundation
 extension ParamModel {
     func applyParamTemplate(name: String,
                             label: String,
-                            type: Type,
+                            type: SwiftType,
                             inInit: Bool) -> String {
         var result = name
         if !label.isEmpty {
@@ -35,7 +35,7 @@ extension ParamModel {
         return result
     }
 
-    func applyVarTemplate(type: `Type`) -> String {
+    func applyVarTemplate(type: SwiftType) -> String {
         assert(!type.isUnknown)
         let vardecl = "\(1.tab)private var \(underlyingName): \(type.underlyingType)"
         return vardecl

--- a/Sources/MockoloFramework/Templates/TypeAliasTemplate.swift
+++ b/Sources/MockoloFramework/Templates/TypeAliasTemplate.swift
@@ -18,7 +18,7 @@ import Foundation
 
 extension TypeAliasModel {
     func applyTypealiasTemplate(name: String,
-                                type: Type,
+                                type: SwiftType,
                                 acl: String) -> String {
         var aclStr = acl
         if !aclStr.isEmpty {

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -19,7 +19,7 @@ import Foundation
 extension VariableModel {
 
     func applyVariableTemplate(name: String,
-                               type: Type,
+                               type: SwiftType,
                                encloser: String,
                                isStatic: Bool,
                                customModifiers: [String: Modifier]?,
@@ -82,7 +82,7 @@ extension VariableModel {
     }
 
     func applyCombineVariableTemplate(name: String,
-                                      type: Type,
+                                      type: SwiftType,
                                       encloser: String,
                                       shouldOverride: Bool,
                                       isStatic: Bool,
@@ -105,7 +105,7 @@ extension VariableModel {
             let nextIndex = typeParamStr.index(after: lastCommaIndex)
             errorTypeStr = String(typeParamStr[nextIndex..<typeParamStr.endIndex]).trimmingCharacters(in: .whitespaces)
         }
-        let subjectType = Type(subjectTypeStr)
+        let subjectType = SwiftType(subjectTypeStr)
         let subjectDefaultValue = subjectType.defaultVal()
         let staticSpace = isStatic ? "\(String.static) " : ""
         let acl = accessLevel.isEmpty ? "" : accessLevel + " "
@@ -168,7 +168,7 @@ extension VariableModel {
     }
 
     func applyRxVariableTemplate(name: String,
-                                 type: Type,
+                                 type: SwiftType,
                                  encloser: String,
                                  rxTypes: [String: String]?,
                                  shouldOverride: Bool,

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -39,6 +39,8 @@ extension String {
     static let `static` = "static"
     static let importSpace = "import "
     static public let `class` = "class"
+    static let `actor` = "actor"
+    static let actorProtocol = "Actor"
     static public let `final` = "final"
     static let override = "override"
     static let privateSet = "private(set)"

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -165,10 +165,10 @@ extension String {
 
 
     func canBeInitParam(type: String, isStatic: Bool) -> Bool {
-        return !(isStatic || type == .unknownVal || type.hasPrefix(.anyPublisher) || (type.hasSuffix("?") && type.contains(String.closureArrow)) ||  isGenerated(type: Type(type)))
+        return !(isStatic || type == .unknownVal || type.hasPrefix(.anyPublisher) || (type.hasSuffix("?") && type.contains(String.closureArrow)) ||  isGenerated(type: SwiftType(type)))
     }
 
-    func isGenerated(type: Type) -> Bool {
+    func isGenerated(type: SwiftType) -> Bool {
           return self.hasPrefix(.underlyingVarPrefix) ||
               self.hasSuffix(.setCallCountSuffix) ||
               self.hasSuffix(.callCountSuffix) ||

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -22,7 +22,7 @@ fileprivate var validIdentifierChars: CharacterSet = {
     return valid
 }()
 
-public final class `Type` {
+public final class SwiftType {
     let typeName: String
     let cast: String?
     var cachedDefaultVal: String?
@@ -58,7 +58,7 @@ public final class `Type` {
         }
         let sliceLast = typeName.index(before: typeName.endIndex)
         let slice = typeName[typeName.startIndex..<sliceLast]
-        let sub = Type(String(slice))
+        let sub = SwiftType(String(slice))
         return sub.isSingular
     }
 
@@ -69,7 +69,7 @@ public final class `Type` {
         }
         let sliceLast = typeName.index(before: typeName.endIndex)
         let slice = typeName[typeName.startIndex..<sliceLast]
-        let sub = Type(String(slice))
+        let sub = SwiftType(String(slice))
         return sub.isSingular
     }
 
@@ -147,8 +147,8 @@ public final class `Type` {
             let leftHalf = String(arg[arg.startIndex..<closureOpRange.lowerBound])
             let rightHalf = String(arg[arg.index(after: closureOpRange.upperBound)..<arg.endIndex])
 
-            let l = Type(leftHalf)
-            let r = Type(rightHalf)
+            let l = SwiftType(leftHalf)
+            let r = SwiftType(rightHalf)
 
             if l.isSingular || r.isSingular {
                 return true
@@ -363,7 +363,7 @@ public final class `Type` {
             return cachedDefaultVal
         }
 
-        if let val = Type.customTypeMap?[typeName] {
+        if let val = SwiftType.customTypeMap?[typeName] {
             cachedDefaultVal = val
             return val
         }
@@ -396,7 +396,7 @@ public final class `Type` {
             } else if subjectKind == String.replaySubject {
                 underlyingSubjectTypeDefaultVal = "\(underlyingSubjectType)\(String.replaySubjectCreate)"
             } else if subjectKind == String.behaviorSubject {
-                if let val = Type(String(typeParamStr)).defaultSingularVal(isInitParam: isInitParam, overrides: overrides, overrideKey: overrideKey) {
+                if let val = SwiftType(String(typeParamStr)).defaultSingularVal(isInitParam: isInitParam, overrides: overrides, overrideKey: overrideKey) {
                     underlyingSubjectTypeDefaultVal = "\(underlyingSubjectType)(value: \(val))"
                 }
             }
@@ -426,7 +426,7 @@ public final class `Type` {
             if sub == "," || sub == ":" || sub == "(" || sub == ")" || sub == "=" || sub == " " || sub == "" {
                 vals.append(sub)
             } else {
-                if let val = Type(sub).defaultSingularVal(isInitParam: isInitParam) {
+                if let val = SwiftType(sub).defaultSingularVal(isInitParam: isInitParam) {
                     vals.append(val)
                 } else {
                     return nil
@@ -465,7 +465,7 @@ public final class `Type` {
             return "\(arg.typeName)()"
         }
 
-        if let val = Type.defaultTypeValueMap[arg.typeName] {
+        if let val = SwiftType.defaultTypeValueMap[arg.typeName] {
             return val
         }
         return nil
@@ -511,10 +511,10 @@ public final class `Type` {
     }
 
 
-    static func toClosureType(with params: [Type], typeParams: [String], suffix: String, returnType: Type, encloser: String) -> Type {
+    static func toClosureType(with params: [SwiftType], typeParams: [String], suffix: String, returnType: SwiftType, encloser: String) -> SwiftType {
 
 
-        let displayableParamTypes = params.map { (subtype: Type) -> String in
+        let displayableParamTypes = params.map { (subtype: SwiftType) -> String in
             return subtype.processTypeParams(with: typeParams)
         }
 
@@ -564,12 +564,12 @@ public final class `Type` {
         ].compactMap { $0 }.joined()
 
         let typeStr = "((\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType))?"
-        return Type(typeStr, cast: returnTypeCast)
+        return SwiftType(typeStr, cast: returnTypeCast)
     }
     
-    static func toArgumentsHistoryType(with params: [Type], typeParams: [String]) -> Type {
+    static func toArgumentsHistoryType(with params: [SwiftType], typeParams: [String]) -> SwiftType {
         // Expected only history capturable types.
-        let displayableParamTypes = params.compactMap { (subtype: Type) -> String? in
+        let displayableParamTypes = params.compactMap { (subtype: SwiftType) -> String? in
             var processedType = subtype.processTypeParams(with: typeParams)
             
             if subtype.isInOut {
@@ -585,9 +585,9 @@ public final class `Type` {
         let displayableParamStr = displayableParamTypes.joined(separator: ", ")
 
         if displayableParamTypes.count >= 2 {
-            return Type("[(\(displayableParamStr))]")
+            return SwiftType("[(\(displayableParamStr))]")
         } else {
-            return Type("[\(displayableParamStr)]")
+            return SwiftType("[\(displayableParamStr)]")
         }
     }
 

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -22,6 +22,7 @@ fileprivate var validIdentifierChars: CharacterSet = {
     return valid
 }()
 
+/// Decl(e.g. class/struct/protocol/enum) or return type (e.g. var/func)
 public final class SwiftType {
     let typeName: String
     let cast: String?

--- a/Tests/MockoloTestCase.swift
+++ b/Tests/MockoloTestCase.swift
@@ -148,10 +148,7 @@ class MockoloTestCase: XCTestCase {
                 let output = (try? String(contentsOf: URL(fileURLWithPath: self.defaultDstFilePath), encoding: .utf8)) ?? ""
                 let outputContents = output.components(separatedBy:  .whitespacesAndNewlines).filter{!$0.isEmpty}
                 let fixtureContents = formattedDstContent.components(separatedBy: .whitespacesAndNewlines).filter{!$0.isEmpty}
-                #if TEST
-                print(output)
-                #endif
-                XCTAssert(fixtureContents == outputContents)
+                XCTAssert(fixtureContents == outputContents, "output:\n" + output)
         })
     }
 }

--- a/Tests/TestActor/ActorTests.swift
+++ b/Tests/TestActor/ActorTests.swift
@@ -1,0 +1,11 @@
+final class ActorTests: MockoloTestCase {
+    func testActorProtocol() {
+        verify(srcContent: actorProtocol,
+               dstContent: actorProtocolMock)
+    }
+
+    func testParentProtocolInheritsActor() {
+        verify(srcContent: parentProtocolInheritsActor,
+               dstContent: parentProtocolInheritsActorMock)
+    }
+}

--- a/Tests/TestActor/FixtureActor.swift
+++ b/Tests/TestActor/FixtureActor.swift
@@ -1,0 +1,64 @@
+import MockoloFramework
+
+let actorProtocol = """
+/// \(String.mockAnnotation)
+protocol Foo: Actor {
+    func foo(arg: String) async -> Result<String, Error>
+    var bar: Int { get }
+}
+"""
+
+let actorProtocolMock = """
+actor FooMock: Foo {
+    init() { }
+    init(bar: Int = 0) {
+        self.bar = bar
+    }
+    private(set) var fooCallCount = 0
+    var fooHandler: ((String) async -> (Result<String, Error>))?
+    func foo(arg: String) async -> Result<String, Error> {
+        fooCallCount += 1
+        if let fooHandler = fooHandler {
+            return await fooHandler(arg)
+        }
+        fatalError("fooHandler returns can't have a default value thus its handler must be set")
+    }
+    private(set) var barSetCallCount = 0
+    var bar: Int = 0 { didSet { barSetCallCount += 1 } }
+}
+"""
+
+
+let parentProtocolInheritsActor = """
+protocol Bar: Actor {
+    var bar: Int { get }
+}
+
+/// \(String.mockAnnotation)
+protocol Foo: Bar {
+    func baz(arg: String) async -> Int
+}
+"""
+
+let parentProtocolInheritsActorMock = """
+actor FooMock: Foo {
+    init() { }
+    init(bar: Int = 0) {
+        self.bar = bar
+    }
+
+
+    private(set) var barSetCallCount = 0
+    var bar: Int = 0 { didSet { barSetCallCount += 1 } }
+
+    private(set) var bazCallCount = 0
+    var bazHandler: ((String) async -> (Int))?
+    func baz(arg: String) async -> Int {
+        bazCallCount += 1
+        if let bazHandler = bazHandler {
+            return await bazHandler(arg)
+        }
+        return 0
+    }
+}
+"""


### PR DESCRIPTION
https://github.com/uber/mockolo/issues/216

When the mock inherits the `Actor` protocol, the mock becomes `actor` automatically.

