### PR TITLE
Add async and throwing property support

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -4,7 +4,6 @@ final class ArgumentsHistoryModel: Model {
     var name: String
     var type: SwiftType
     var offset: Int64 = .max
-    let suffix: String
     let capturableParamNames: [String]
     let capturableParamTypes: [SwiftType]
     let isHistoryAnnotated: Bool
@@ -13,7 +12,7 @@ final class ArgumentsHistoryModel: Model {
         return .argumentsHistory
     }
 
-    init?(name: String, genericTypeParams: [ParamModel], params: [ParamModel], isHistoryAnnotated: Bool, suffix: String) {
+    init?(name: String, genericTypeParams: [ParamModel], params: [ParamModel], isHistoryAnnotated: Bool) {
         // Value contains closure is not supported.
         let capturables = params.filter { !$0.type.hasClosure && !$0.type.isEscaping && !$0.type.isAutoclosure }
         guard !capturables.isEmpty else {
@@ -21,7 +20,6 @@ final class ArgumentsHistoryModel: Model {
         }
         
         self.name = name + .argsHistorySuffix
-        self.suffix = suffix
         self.isHistoryAnnotated = isHistoryAnnotated
 
         self.capturableParamNames = capturables.map(\.name.safeName)

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -24,31 +24,36 @@ final class ClosureModel: Model {
     let genericTypeNames: [String]
     let paramNames: [String]
     let paramTypes: [SwiftType]
-    let suffix: String
+    let isAsync: Bool
+    let throwing: ThrowingKind
 
     var modelType: ModelType {
         return .closure
     }
-
     
-    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [SwiftType], suffix: String, returnType: SwiftType, encloser: String) {
+    init(name: String, genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [SwiftType], isAsync: Bool, throwing: ThrowingKind, returnType: SwiftType, encloser: String) {
         self.name = name + .handlerSuffix
-        self.suffix = suffix
+        self.isAsync = isAsync
+        self.throwing = throwing
         let genericTypeNameList = genericTypeParams.map(\.name)
         self.genericTypeNames = genericTypeNameList
         self.paramNames = paramNames
         self.paramTypes = paramTypes
         self.funcReturnType = returnType
-        self.type = SwiftType.toClosureType(with: paramTypes, typeParams: genericTypeNameList, suffix: suffix, returnType: returnType, encloser: encloser)
+        self.type = SwiftType.toClosureType(
+            params: paramTypes,
+            typeParams: genericTypeNameList,
+            isAsync: isAsync,
+            throwing: throwing,
+            returnType: returnType,
+            encloser: encloser
+        )
     }
     
     func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {
         return applyClosureTemplate(name: identifier + .handlerSuffix,
-                                    type: type,
-                                    genericTypeNames: genericTypeNames,
                                     paramVals: paramNames,
                                     paramTypes: paramTypes,
-                                    suffix: suffix,
                                     returnDefaultType: funcReturnType)
     }
 }

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -38,7 +38,8 @@ final class MethodModel: Model {
     var modelDescription: String? = nil
     var isStatic: Bool
     let shouldOverride: Bool
-    let suffix: String
+    let isAsync: Bool
+    let throwing: ThrowingKind
     let kind: MethodKind
     let funcsWithArgsHistory: [String]
     let customModifiers: [String : Modifier]
@@ -134,8 +135,7 @@ final class MethodModel: Model {
         let ret = ArgumentsHistoryModel(name: name,
                                         genericTypeParams: genericTypeParams,
                                         params: params,
-                                        isHistoryAnnotated: funcsWithArgsHistory.contains(name),
-                                        suffix: suffix)
+                                        isHistoryAnnotated: funcsWithArgsHistory.contains(name))
 
         return ret
     }()
@@ -151,7 +151,8 @@ final class MethodModel: Model {
                                genericTypeParams: genericTypeParams,
                                paramNames: paramNames,
                                paramTypes: paramTypes,
-                               suffix: suffix,
+                               isAsync: isAsync,
+                               throwing: throwing,
                                returnType: type,
                                encloser: encloser)
 
@@ -167,8 +168,8 @@ final class MethodModel: Model {
          genericTypeParams: [ParamModel],
          genericWhereClause: String?,
          params: [ParamModel],
-         throwsOrRethrows: String?,
-         asyncOrReasync: String?,
+         isAsync: Bool,
+         throwing: ThrowingKind,
          isStatic: Bool,
          offset: Int64,
          length: Int64,
@@ -178,7 +179,8 @@ final class MethodModel: Model {
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
         self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
-        self.suffix = [asyncOrReasync, throwsOrRethrows].compactMap { $0 }.joined(separator: " ")
+        self.isAsync = isAsync
+        self.throwing = throwing
         self.offset = offset
         self.length = length
         self.kind = kind
@@ -237,7 +239,6 @@ final class MethodModel: Model {
                                          params: params,
                                          returnType: type,
                                          accessLevel: accessLevel,
-                                         suffix: suffix,
                                          argsHistory: argsHistory,
                                          handler: handler(encloser: encloser))
         return result

--- a/Sources/MockoloFramework/Models/ThrowingKind.swift
+++ b/Sources/MockoloFramework/Models/ThrowingKind.swift
@@ -1,0 +1,32 @@
+enum ThrowingKind: Equatable {
+    case none
+    case any
+    case `rethrows`
+    case typed(errorType: String)
+
+    var hasError: Bool {
+        switch self {
+        case .none:
+            return false
+        case .any:
+            return true
+        case .rethrows:
+            return true
+        case .typed(let errorType):
+            return errorType != .neverType && errorType != "Swift.\(String.neverType)"
+        }
+    }
+
+    var syntax: String? {
+        switch self {
+        case .none:
+            return nil
+        case .any:
+            return .throws
+        case .rethrows:
+            return .rethrows
+        case .typed(let errorType):
+            return "\(String.throws)(\(errorType))"
+        }
+    }
+}

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -36,7 +36,7 @@ final class VariableModel: Model {
     }
 
     var underlyingName: String {
-        if isStatic || type.defaultVal() == nil {
+        if type.defaultVal() == nil {
             return "_\(name)"
         }
         return name

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -1,6 +1,11 @@
 import Foundation
 
 final class VariableModel: Model {
+    enum GetterEffect: Hashable {
+        case async
+        case `throws`(errorType: String?)
+    }
+
     var name: String
     var type: SwiftType
     var offset: Int64
@@ -13,6 +18,8 @@ final class VariableModel: Model {
     var filePath: String = ""
     var isStatic = false
     var shouldOverride = false
+    let getterEffects: Set<GetterEffect>
+    let hasSetter: Bool
     var rxTypes: [String: String]?
     var customModifiers: [String: Modifier]?
     var modelDescription: String? = nil
@@ -40,6 +47,8 @@ final class VariableModel: Model {
          acl: String?,
          encloserType: DeclType,
          isStatic: Bool,
+         getterEffects: Set<GetterEffect>,
+         hasSetter: Bool,
          canBeInitParam: Bool,
          offset: Int64,
          rxTypes: [String: String]?,
@@ -51,6 +60,8 @@ final class VariableModel: Model {
         self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
         self.offset = offset
         self.isStatic = isStatic
+        self.getterEffects = getterEffects
+        self.hasSetter = hasSetter
         self.shouldOverride = encloserType == .classType
         self.canBeInitParam = canBeInitParam
         self.processed = processed

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -11,7 +11,7 @@ final class VariableModel: Model {
         static let empty: GetterEffects = .init(isAsync: false, throws: .none)
     }
 
-    enum /* Mock */StorageType {
+    enum MockStorageType {
         case stored(needsSetCount: Bool)
         case computed(GetterEffects)
     }
@@ -28,7 +28,7 @@ final class VariableModel: Model {
     var filePath: String = ""
     var isStatic = false
     var shouldOverride = false
-    let storageType: StorageType
+    let storageType: MockStorageType
     var rxTypes: [String: String]?
     var customModifiers: [String: Modifier]?
     var modelDescription: String? = nil
@@ -56,7 +56,7 @@ final class VariableModel: Model {
          acl: String?,
          encloserType: DeclType,
          isStatic: Bool,
-         storageType: StorageType,
+         storageType: MockStorageType,
          canBeInitParam: Bool,
          offset: Int64,
          rxTypes: [String: String]?,

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -3,12 +3,8 @@ import Foundation
 final class VariableModel: Model {
     struct GetterEffects: Equatable {
         var isAsync: Bool
-        enum ThrowsType: Equatable {
-            case throwing(errorType: String?)
-            case none
-        }
-        var `throws`: ThrowsType
-        static let empty: GetterEffects = .init(isAsync: false, throws: .none)
+        var throwing: ThrowingKind
+        static let empty: GetterEffects = .init(isAsync: false, throwing: .none)
     }
 
     enum MockStorageType {

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -1,9 +1,19 @@
 import Foundation
 
 final class VariableModel: Model {
-    enum GetterEffect: Hashable {
-        case async
-        case `throws`(errorType: String?)
+    struct GetterEffects: Equatable {
+        var isAsync: Bool
+        enum ThrowsType: Equatable {
+            case throwing(errorType: String?)
+            case none
+        }
+        var `throws`: ThrowsType
+        static let empty: GetterEffects = .init(isAsync: false, throws: .none)
+    }
+
+    enum /* Mock */StorageType {
+        case stored(needsSetCount: Bool)
+        case computed(GetterEffects)
     }
 
     var name: String
@@ -18,8 +28,7 @@ final class VariableModel: Model {
     var filePath: String = ""
     var isStatic = false
     var shouldOverride = false
-    let getterEffects: Set<GetterEffect>
-    let hasSetter: Bool
+    let storageType: StorageType
     var rxTypes: [String: String]?
     var customModifiers: [String: Modifier]?
     var modelDescription: String? = nil
@@ -47,8 +56,7 @@ final class VariableModel: Model {
          acl: String?,
          encloserType: DeclType,
          isStatic: Bool,
-         getterEffects: Set<GetterEffect>,
-         hasSetter: Bool,
+         storageType: StorageType,
          canBeInitParam: Bool,
          offset: Int64,
          rxTypes: [String: String]?,
@@ -60,8 +68,7 @@ final class VariableModel: Model {
         self.type = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
         self.offset = offset
         self.isStatic = isStatic
-        self.getterEffects = getterEffects
-        self.hasSetter = hasSetter
+        self.storageType = storageType
         self.shouldOverride = encloserType == .classType
         self.canBeInitParam = canBeInitParam
         self.processed = processed

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -380,11 +380,7 @@ extension VariableDeclSyntax {
                             getterEffects.isAsync = true
                         }
                         if let `throws` = getterDecl.effectSpecifiers?.throwsClause {
-                            if let throwsType = `throws`.type {
-                                getterEffects.throwing = .typed(errorType: throwsType.trimmedDescription)
-                            } else {
-                                getterEffects.throwing = .any
-                            }
+                            getterEffects.throwing = .init(`throws`)
                         }
                         if getterEffects == .empty {
                             storageType = .stored(needsSetCount: false)

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -368,7 +368,7 @@ extension VariableDeclSyntax {
                 typeName = vtype
             }
 
-            let storageType: VariableModel.StorageType
+            let storageType: VariableModel.MockStorageType
             switch v.accessorBlock?.accessors {
             case .accessors(let accessorDecls):
                 if accessorDecls.contains(where: { $0.accessorSpecifier.tokenKind == .keyword(.set) }) {

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -18,11 +18,8 @@ import Foundation
 
 extension ClosureModel {
     func applyClosureTemplate(name: String,
-                              type: SwiftType,
-                              genericTypeNames: [String],
                               paramVals: [String]?,
                               paramTypes: [SwiftType]?,
-                              suffix: String,
                               returnDefaultType: SwiftType) -> String {
         
         var handlerParamValsStr = ""
@@ -46,8 +43,8 @@ extension ClosureModel {
         let handlerReturnDefault = renderReturnDefaultStatement(name: name, type: returnDefaultType)
         
         let prefix = [
-            suffix.hasThrowsOrRethrows ? String.try + " " : nil,
-            suffix.hasAsync ? String.await + " " : nil,
+            throwing.hasError ? String.try + " " : nil,
+            isAsync ? String.await + " " : nil,
         ].compactMap { $0 }.joined()
         
         let returnStr = returnDefaultType.typeName.isEmpty ? "" : "return "

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -60,7 +60,7 @@ extension MethodModel {
 
             let suffixStr = [
                 isAsync ? String.async : nil,
-                throwing.syntax,
+                throwing.applyThrowingTemplate(),
             ].compactMap { $0 }.joined(separator: " ") + " "
             let returnStr = returnTypeName.isEmpty ? "" : "-> \(returnTypeName)"
             let staticStr = isStatic ? String.static + " " : ""

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -31,7 +31,6 @@ extension MethodModel {
                              params: [ParamModel],
                              returnType: SwiftType,
                              accessLevel: String,
-                             suffix: String,
                              argsHistory: ArgumentsHistoryModel?,
                              handler: ClosureModel?) -> String {
         var template = ""
@@ -59,14 +58,17 @@ extension MethodModel {
             let handlerVarType = handler.type.typeName // ?? "Any"
             let handlerReturn = handler.render(with: identifier, encloser: "") ?? ""
 
-            let suffixStr = suffix.isEmpty ? "" : "\(suffix) "
+            let suffixStr = [
+                isAsync ? String.async : nil,
+                throwing.syntax,
+            ].compactMap { $0 }.joined(separator: " ") + " "
             let returnStr = returnTypeName.isEmpty ? "" : "-> \(returnTypeName)"
             let staticStr = isStatic ? String.static + " " : ""
             let keyword = isSubscript ? "" : "func "
             var body = ""
 
             if useTemplateFunc {
-                let callMockFunc = !suffix.hasThrowsOrRethrows && (handler.type.cast?.isEmpty ?? false)
+                let callMockFunc = !throwing.hasError && (handler.type.cast?.isEmpty ?? false)
                 if callMockFunc {
                     let handlerParamValsStr = params.map { (arg) -> String in
                         if arg.type.typeName.hasPrefix(String.autoclosure) {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -166,7 +166,7 @@ extension NominalModel {
                 case .stored:
                     return "\(2.tab)self.\(element.underlyingName) = \(element.name.safeName)"
                 case .computed:
-                    return "\(2.tab)self.\(element.name)Handler = { \(element.name.safeName) }"
+                    return "\(2.tab)self.\(element.name)\(String.handlerSuffix) = { \(element.name.safeName) }"
                 }
             }.joined(separator: "\n")
             

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -198,7 +198,10 @@ extension NominalModel {
                 let genericTypeDeclsStr = m.genericTypeParams.compactMap {$0.render(with: "", encloser: "")}.joined(separator: ", ")
                 let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
                 let paramDeclsStr = m.params.compactMap{$0.render(with: "", encloser: "")}.joined(separator: ", ")
-                let suffixStr = m.suffix.isEmpty ? "" : "\(m.suffix) "
+                let suffixStr = [
+                    m.isAsync ? String.async : nil,
+                    m.throwing.syntax,
+                ].compactMap { $0 }.joined(separator: " ") + " "
 
                 if override {
                     let paramsList = m.params.map { param in

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -200,7 +200,7 @@ extension NominalModel {
                 let paramDeclsStr = m.params.compactMap{$0.render(with: "", encloser: "")}.joined(separator: ", ")
                 let suffixStr = [
                     m.isAsync ? String.async : nil,
-                    m.throwing.syntax,
+                    m.throwing.applyThrowingTemplate(),
                 ].compactMap { $0 }.joined(separator: " ") + " "
 
                 if override {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -147,8 +147,8 @@ extension NominalModel {
         if needParamedInit {
             var paramsAssign = ""
             let params = initParamCandidates
-                .map { (element: Model) -> String in
-                    if let val =  element.type.defaultVal(with: overrides, overrideKey: element.name, isInitParam: true) {
+                .map { (element: VariableModel) -> String in
+                    if let val = element.type.defaultVal(with: overrides, overrideKey: element.name, isInitParam: true) {
                         return "\(element.name): \(element.type.typeName) = \(val)"
                     }
                     var prefix = ""
@@ -158,13 +158,16 @@ extension NominalModel {
                         }
                     }
                     return "\(element.name): \(prefix)\(element.type.typeName)"
-            }
-            .joined(separator: ", ")
+                }
+                .joined(separator: ", ")
 
-            
-            paramsAssign = initParamCandidates.map { p in
-                return "\(2.tab)self.\(p.underlyingName) = \(p.name.safeName)"
-                
+            paramsAssign = initParamCandidates.map { (element: VariableModel) in
+                switch element.storageType {
+                case .stored:
+                    return "\(2.tab)self.\(element.underlyingName) = \(element.name.safeName)"
+                case .computed:
+                    return "\(2.tab)self.\(element.name)Handler = { \(element.name.safeName) }"
+                }
             }.joined(separator: "\n")
             
             initTemplate = """

--- a/Sources/MockoloFramework/Templates/ThrowingKindTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ThrowingKindTemplate.swift
@@ -14,22 +14,17 @@
 //  limitations under the License.
 //
 
-enum ThrowingKind: Equatable {
-    case none
-    case any
-    case `rethrows`
-    case typed(errorType: String)
-
-    var hasError: Bool {
+extension ThrowingKind {
+    func applyThrowingTemplate() -> String? {
         switch self {
         case .none:
-            return false
+            return nil
         case .any:
-            return true
+            return .throws
         case .rethrows:
-            return true
+            return .rethrows
         case .typed(let errorType):
-            return errorType != .neverType && errorType != "Swift.\(String.neverType)"
+            return "\(String.throws)(\(errorType))"
         }
     }
 }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -108,6 +108,7 @@ extension VariableModel {
 
         case .computed(let effects):
             return """
+
             \(1.tab)\(acl)\(staticSpace)var \(name)Handler: (() \(effects.syntax)-> \(type.typeName))?
             \(1.tab)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
             \(2.tab)get \(effects.syntax){ \(effects.callerMarkers)\(name)Handler!() }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -122,9 +122,9 @@ extension VariableModel {
 
             return """
 
-            \(1.tab)\(acl)\(staticSpace)var \(name)\(String.handlerSuffix): (() \(effects.syntax)-> \(type.typeName))?
+            \(1.tab)\(acl)\(staticSpace)var \(name)\(String.handlerSuffix): (() \(effects.applyTemplate())-> \(type.typeName))?
             \(1.tab)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
-            \(2.tab)get \(effects.syntax){
+            \(2.tab)get \(effects.applyTemplate()){
             \(body)
             \(2.tab)}
             \(1.tab)}
@@ -356,20 +356,13 @@ extension VariableModel {
 }
 
 extension VariableModel.GetterEffects {
-    fileprivate var syntax: String {
+    fileprivate func applyTemplate() -> String {
         var clauses: [String] = []
         if isAsync {
             clauses.append(.async)
         }
-        switch throwing {
-        case .none:
-            break
-        case .any:
-            clauses.append(.throws)
-        case .rethrows:
-            clauses.append(.rethrows)
-        case .typed(let errorType):
-            clauses.append("\(String.throws)(\(errorType))")
+        if let throwSyntax = throwing.applyThrowingTemplate() {
+            clauses.append(throwSyntax)
         }
         return clauses.map { "\($0) " }.joined()
     }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -371,27 +371,4 @@ extension VariableModel.GetterEffects {
         }
         return clauses.map { "\($0) " }.joined()
     }
-
-    fileprivate func handlerType(typeName: String) -> String {
-//        if self == .empty {
-//            return nil
-//        }
-
-        var clauses: [String] = []
-        if isAsync {
-            clauses.append(.async)
-        }
-        switch `throws` {
-        case .throwing(let errorType):
-            if let errorType {
-                clauses.append("\(String.throws)(\(errorType))")
-            } else {
-                clauses.append(.throws)
-            }
-        case .none:
-            break
-        }
-
-        return "(() \(clauses.map { "\($0) " }.joined())-> \(typeName))?"
-    }
 }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -48,7 +48,6 @@ extension VariableModel {
         }
 
         let privateSetSpace = allowSetCallCount ? "" :  "\(String.privateSet) "
-        let setCallCountStmt = "\(underlyingSetCallCount) += 1"
 
         let modifierTypeStr: String
         if let customModifiers = self.customModifiers,
@@ -65,7 +64,7 @@ extension VariableModel {
         var accessorBlockItems: [String] = []
         if hasSetter {
             let didSetBlock = """
-            didSet { \(setCallCountStmt) }
+            didSet { \(underlyingSetCallCount) += 1 }
             """
             accessorBlockItems.append(didSetBlock)
         }
@@ -82,7 +81,7 @@ extension VariableModel {
         }
 
         let template: String
-        if isStatic || underlyingVarDefaultVal == nil {
+        if underlyingVarDefaultVal == nil {
             template = """
 
             \(setCallCountVarDecl)
@@ -96,7 +95,7 @@ extension VariableModel {
             template = """
 
             \(setCallCountVarDecl)
-            \(1.tab)\(propertyWrapper)\(acl)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) \(assignVal)\(accessorBlock)
+            \(1.tab)\(propertyWrapper)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) \(assignVal)\(accessorBlock)
             """
         }
 

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -77,8 +77,7 @@ extension VariableModel {
             switch accessorBlockItems.count {
             case 0: accessorBlock = ""
             case 1: accessorBlock = " { \(accessorBlockItems[0]) }"
-            default:
-                accessorBlock = """
+            default: accessorBlock = """
                  {
                 \(accessorBlockItems.map { "\(2.tab)\($0)" }.joined(separator: "\n"))
                 \(1.tab)}

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -48,6 +48,7 @@ extension String {
     static let unknownVal = "Unknown"
     static let prefix = "prefix"
     static let anyType = "Any"
+    static let neverType = "Never"
     static let any = "any"
     static let some = "some"
     static let anyObject = "AnyObject"
@@ -111,12 +112,14 @@ extension String {
     """
 
 
+    @available(*, deprecated)
     var hasThrowsOrRethrows: Bool {
         return components(separatedBy: .whitespaces).contains { component in
             return component == .throws || component == .rethrows
         }
     }
 
+    @available(*, deprecated)
     var hasAsync: Bool {
         return components(separatedBy: .whitespaces).contains { component in
             return component == .async

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -111,21 +111,6 @@ extension String {
     ///
     """
 
-
-    @available(*, deprecated)
-    var hasThrowsOrRethrows: Bool {
-        return components(separatedBy: .whitespaces).contains { component in
-            return component == .throws || component == .rethrows
-        }
-    }
-
-    @available(*, deprecated)
-    var hasAsync: Bool {
-        return components(separatedBy: .whitespaces).contains { component in
-            return component == .async
-        }
-    }
-
     var safeName: String {
         var text = self
         if let keyword = text.withSyntaxText(Keyword.init),

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -512,9 +512,14 @@ public final class SwiftType {
     }
 
 
-    static func toClosureType(with params: [SwiftType], typeParams: [String], suffix: String, returnType: SwiftType, encloser: String) -> SwiftType {
-
-
+    static func toClosureType(
+        params: [SwiftType],
+        typeParams: [String],
+        isAsync: Bool,
+        throwing: ThrowingKind,
+        returnType: SwiftType,
+        encloser: String
+    ) -> SwiftType {
         let displayableParamTypes = params.map { (subtype: SwiftType) -> String in
             return subtype.processTypeParams(with: typeParams)
         }
@@ -560,8 +565,8 @@ public final class SwiftType {
         }
 
         let suffixStr = [
-            suffix.hasAsync ? String.async + " " : nil,
-            suffix.hasThrowsOrRethrows ? String.throws + " " : nil,
+            isAsync ? String.async + " " : nil,
+            throwing.hasError ? String.throws + " " : nil,
         ].compactMap { $0 }.joined()
 
         let typeStr = "((\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType))?"

--- a/Tests/TestActor/FixtureActor.swift
+++ b/Tests/TestActor/FixtureActor.swift
@@ -23,8 +23,8 @@ actor FooMock: Foo {
         }
         fatalError("fooHandler returns can't have a default value thus its handler must be set")
     }
-    private(set) var barSetCallCount = 0
-    var bar: Int = 0 { didSet { barSetCallCount += 1 } }
+
+    var bar: Int = 0
 }
 """
 
@@ -48,8 +48,7 @@ actor FooMock: Foo {
     }
 
 
-    private(set) var barSetCallCount = 0
-    var bar: Int = 0 { didSet { barSetCallCount += 1 } }
+    var bar: Int = 0
 
     private(set) var bazCallCount = 0
     var bazHandler: ((String) async -> (Int))?

--- a/Tests/TestCombine/FixtureCombine.swift
+++ b/Tests/TestCombine/FixtureCombine.swift
@@ -225,22 +225,19 @@ public class FooMock: Foo {
     public init() { }
 
 
-    public private(set) var myPublisherSetCallCount = 0
-    private var _myPublisher: AnyPublisher<String, Never>!  { didSet { myPublisherSetCallCount += 1 } }
+    private var _myPublisher: AnyPublisher<String, Never>!
     public var myPublisher: AnyPublisher<String, Never> {
         get { return _myPublisher }
         set { _myPublisher = newValue }
     }
 
-    public private(set) var dictionaryPublisherSetCallCount = 0
-    private var _dictionaryPublisher: AnyPublisher<Dictionary<String, String>, Never>!  { didSet { dictionaryPublisherSetCallCount += 1 } }
+    private var _dictionaryPublisher: AnyPublisher<Dictionary<String, String>, Never>!
     public var dictionaryPublisher: AnyPublisher<Dictionary<String, String>, Never> {
         get { return _dictionaryPublisher }
         set { _dictionaryPublisher = newValue }
     }
 
-    public private(set) var noDefaultSubjectValueSetCallCount = 0
-    private var _noDefaultSubjectValue: AnyPublisher<CustomType, Never>!  { didSet { noDefaultSubjectValueSetCallCount += 1 } }
+    private var _noDefaultSubjectValue: AnyPublisher<CustomType, Never>!
     public var noDefaultSubjectValue: AnyPublisher<CustomType, Never> {
         get { return _noDefaultSubjectValue }
         set { _noDefaultSubjectValue = newValue }

--- a/Tests/TestExistentialAny/FixtureExistentialAny.swift
+++ b/Tests/TestExistentialAny/FixtureExistentialAny.swift
@@ -20,29 +20,25 @@ class ExistentialAnyMock: ExistentialAny {
     }
 
 
-    private(set) var fooSetCallCount = 0
-    private var _foo: P!  { didSet { fooSetCallCount += 1 } }
+    private var _foo: P!
     var foo: P {
         get { return _foo }
         set { _foo = newValue }
     }
 
-    private(set) var barSetCallCount = 0
-    private var _bar: (any R<Int>)!  { didSet { barSetCallCount += 1 } }
+    private var _bar: (any R<Int>)!
     var bar: any R<Int> {
         get { return _bar }
         set { _bar = newValue }
     }
 
-    private(set) var bazSetCallCount = 0
-    private var _baz: (any P & Q)!  { didSet { bazSetCallCount += 1 } }
+    private var _baz: (any P & Q)!
     var baz: any P & Q {
         get { return _baz }
         set { _baz = newValue }
     }
 
-    private(set) var quxSetCallCount = 0
-    private var _qux: ((any P) -> any P)!  { didSet { quxSetCallCount += 1 } }
+    private var _qux: ((any P) -> any P)!
     var qux: (any P) -> any P {
         get { return _qux }
         set { _qux = newValue }

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -370,7 +370,7 @@ import Foundation
 
 /// \(String.mockAnnotation)
 protocol NonSimpleFuncs {
-func pass<T>(handler: @autoclosure () -> Int) rethrows -> T
+func pass<T>(handler: @autoclosure () -> Int) throws -> T
 }
 """
 
@@ -385,7 +385,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
     private(set) var passCallCount = 0
     var passHandler: ((@autoclosure () -> Int) throws -> (Any))?
-    func pass<T>(handler: @autoclosure () -> Int) rethrows -> T {
+    func pass<T>(handler: @autoclosure () -> Int) throws -> T {
         passCallCount += 1
         if let passHandler = passHandler {
             return try passHandler(handler()) as! T

--- a/Tests/TestModifiersTypes/FixtureModifiersTypes.swift
+++ b/Tests/TestModifiersTypes/FixtureModifiersTypes.swift
@@ -17,8 +17,7 @@ class FooMock: Foo {
     }
 
 
-    private(set) var listenerSetCallCount = 0
-    weak var listener: AnyObject? = nil { didSet { listenerSetCallCount += 1 } }
+    weak var listener: AnyObject? = nil
 
     private(set) var barFuncCallCount = 0
     var barFuncHandler: (([Int]) -> ())?
@@ -60,8 +59,8 @@ class FooMock: Foo {
     }
 
 
-    private(set) var listenerSetCallCount = 0
-    dynamic var listener: AnyObject? = nil { didSet { listenerSetCallCount += 1 } }
+
+    dynamic var listener: AnyObject? = nil
 
     private(set) var barFuncCallCount = 0
     var barFuncHandler: (([Int]) -> ())?
@@ -103,8 +102,8 @@ class FooMock: Foo {
     }
 
 
-    private(set) var listenerSetCallCount = 0
-    var listener: AnyObject? = nil { didSet { listenerSetCallCount += 1 } }
+
+    var listener: AnyObject? = nil
 
     private(set) var barFuncCallCount = 0
     var barFuncHandler: (([Int]) -> ())?

--- a/Tests/TestModuleNames/FixtureModuleOverrides.swift
+++ b/Tests/TestModuleNames/FixtureModuleOverrides.swift
@@ -17,8 +17,8 @@ class TaskRoutingMock: Foo.TaskRouting {
     init(bar: String = "") {
         self.bar = bar
     }
-    private(set) var barSetCallCount = 0
-    var bar: String = "" { didSet { barSetCallCount += 1 } }
+
+    var bar: String = ""
     private(set) var bazCallCount = 0
     var bazHandler: (() -> (Double))?
     func baz() -> Double {

--- a/Tests/TestOverloads/FixtureDuplicates4.swift
+++ b/Tests/TestOverloads/FixtureDuplicates4.swift
@@ -110,7 +110,7 @@ public class FooMock: Foo {
 
 let sameNameVarFunc = """
 /// \(String.mockAnnotation)
-public protocol Bar: class {
+public protocol Bar: AnyObject {
 var talk: Int { get }
 }
 
@@ -131,8 +131,8 @@ public class BarMock: Bar {
         self.talk = talk
         
     }
-    public private(set) var talkSetCallCount = 0
-    public var talk: Int = 0 { didSet { talkSetCallCount += 1 } }
+
+    public var talk: Int = 0
 }
 
 public class FooMock: Foo {
@@ -144,8 +144,8 @@ public class FooMock: Foo {
         self.talk = talk
         
     }
-    public private(set) var talkSetCallCount = 0
-    public var talk: Int = 0 { didSet { talkSetCallCount += 1 } }
+
+    public var talk: Int = 0
     public private(set) var talkDismissCallCount = 0
     public var talkDismissHandler: ((Bool) -> ())?
     public func talk(_ dismiss: Bool)  {

--- a/Tests/TestOverloads/FixtureInheritance.swift
+++ b/Tests/TestOverloads/FixtureInheritance.swift
@@ -111,8 +111,8 @@ class TestProtocolMock: TestProtocol {
     }
 
 
-    private(set) var someBoolSetCallCount = 0
-    var someBool: Bool = false { didSet { someBoolSetCallCount += 1 } }
+
+    var someBool: Bool = false
 
     private(set) var doSomethingCallCount = 0
     var doSomethingHandler: (() -> ())?

--- a/Tests/TestPATs/FixturePAT.swift
+++ b/Tests/TestPATs/FixturePAT.swift
@@ -152,8 +152,8 @@ public class SomeTypeMock: SomeType {
         self._key = key
     }
     public typealias Key = String
-    public private(set) var keySetCallCount = 0
-    private var _key: Key!  { didSet { keySetCallCount += 1 } }
+    
+    private var _key: Key!
     public var key: Key {
         get { return _key }
         set { _key = newValue }

--- a/Tests/TestRx/FixtureRxVars.swift
+++ b/Tests/TestRx/FixtureRxVars.swift
@@ -27,25 +27,25 @@ public class FooMock: Foo {
         self.someBar = someBar
     }
 
-    public private(set) var someBehaviorSetCallCount = 0
-    private var _someBehavior: BehaviorSubject<String>!  { didSet { someBehaviorSetCallCount += 1 } }
+
+    private var _someBehavior: BehaviorSubject<String>!
     public var someBehavior: BehaviorSubject<String> {
         get { return _someBehavior }
         set { _someBehavior = newValue }
     }
 
-    public private(set) var someReplySetCallCount = 0
-    public var someReply: ReplaySubject<String> = ReplaySubject<String>.create(bufferSize: 1) { didSet { someReplySetCallCount += 1 } }
 
-    public private(set) var someVariableSetCallCount = 0
-    private var _someVariable: Variable<Bool>!  { didSet { someVariableSetCallCount += 1 } }
+    public var someReply: ReplaySubject<String> = ReplaySubject<String>.create(bufferSize: 1)
+
+
+    private var _someVariable: Variable<Bool>!
     public var someVariable: Variable<Bool> {
         get { return _someVariable }
         set { _someVariable = newValue }
     }
 
-    public private(set) var someBarSetCallCount = 0
-    public var someBar: Bar = BarMock() { didSet { someBarSetCallCount += 1 } }
+
+    public var someBar: Bar = BarMock()
 }
 """
 

--- a/Tests/TestVars/FixtureAsyncThrowsVars.swift
+++ b/Tests/TestVars/FixtureAsyncThrowsVars.swift
@@ -1,0 +1,43 @@
+import MockoloFramework
+
+let asyncThrowsVars = """
+/// \(String.mockAnnotation)
+public protocol AsyncThrowsVars {
+    var getOnly: Int { get }
+    static var getAndSet: Int { get set }
+    var getAndThrows: Int { get throws }
+    static var getAndAsync: Int { get async }
+    var getAndAsyncAndThrows: Int { get async throws(any Error) }
+}
+"""
+
+let asyncThrowsVarsMock = """
+public class AsyncThrowsVarsMock: AsyncThrowsVars {
+    public init() { }
+    public init(getOnly: Int = 0, getAndThrows: Int = 0, getAndAsyncAndThrows: Int = 0) {
+        self.getOnly = getOnly
+        self.getAndThrowsHandler = { getAndThrows }
+        self.getAndAsyncAndThrowsHandler = { getAndAsyncAndThrows }
+    }
+
+
+
+    public var getOnly: Int = 0
+
+    public static private(set) var getAndSetSetCallCount = 0
+    public static var getAndSet: Int = 0 { didSet { getAndSetSetCallCount += 1 } }
+    public var getAndThrowsHandler: (() throws -> Int)?
+    public var getAndThrows: Int {
+        get throws { try getAndThrowsHandler!() }
+    }
+    public static var getAndAsyncHandler: (() async -> Int)?
+    public static var getAndAsync: Int {
+        get async { await getAndAsyncHandler!() }
+    }
+    public var getAndAsyncAndThrowsHandler: (() async throws(any Error) -> Int)?
+    public var getAndAsyncAndThrows: Int {
+        get async throws(any Error) { try await getAndAsyncAndThrowsHandler!() }
+    }
+}
+"""
+

--- a/Tests/TestVars/FixtureAsyncThrowsVars.swift
+++ b/Tests/TestVars/FixtureAsyncThrowsVars.swift
@@ -59,3 +59,29 @@ public class AsyncThrowsVarsMock: AsyncThrowsVars {
 }
 """
 
+let throwsNeverVars = """
+/// \(String.mockAnnotation)
+protocol P {
+    var foo: Int { get throws(Never) }
+}
+"""
+
+let throwsNeverVarsMock = """
+class PMock: P {
+    init() { }
+    init(foo: Int = 0) {
+        self.fooHandler = { foo }
+    }
+
+
+    var fooHandler: (() throws(Never) -> Int)?
+    var foo: Int {
+        get throws(Never) {
+            if let fooHandler = fooHandler {
+                return fooHandler()
+            }
+            return 0
+        }
+    }
+}
+"""

--- a/Tests/TestVars/FixtureAsyncThrowsVars.swift
+++ b/Tests/TestVars/FixtureAsyncThrowsVars.swift
@@ -26,14 +26,17 @@ public class AsyncThrowsVarsMock: AsyncThrowsVars {
 
     public static private(set) var getAndSetSetCallCount = 0
     public static var getAndSet: Int = 0 { didSet { getAndSetSetCallCount += 1 } }
+
     public var getAndThrowsHandler: (() throws -> Int)?
     public var getAndThrows: Int {
         get throws { try getAndThrowsHandler!() }
     }
+
     public static var getAndAsyncHandler: (() async -> Int)?
     public static var getAndAsync: Int {
         get async { await getAndAsyncHandler!() }
     }
+
     public var getAndAsyncAndThrowsHandler: (() async throws(any Error) -> Int)?
     public var getAndAsyncAndThrows: Int {
         get async throws(any Error) { try await getAndAsyncAndThrowsHandler!() }

--- a/Tests/TestVars/FixtureNonSimpleVars.swift
+++ b/Tests/TestVars/FixtureNonSimpleVars.swift
@@ -29,19 +29,19 @@ public class NonSimpleVarsMock: NonSimpleVars {
     }
     public private(set) var dictSetCallCount = 0
     public var dict: Dictionary<String, Int> = Dictionary<String, Int>() { didSet { dictSetCallCount += 1 } }
-    public private(set) var closureVarSetCallCount = 0
-    public var closureVar: ((_ arg: String) -> Void)? = nil { didSet { closureVarSetCallCount += 1 } }
-    public private(set) var voidHandlerSetCallCount = 0
-    private var _voidHandler: ((() -> ()))!  { didSet { voidHandlerSetCallCount += 1 } }
+
+    public var closureVar: ((_ arg: String) -> Void)? = nil
+
+    private var _voidHandler: ((() -> ()))!
     public var voidHandler: (() -> ()) {
         get { return _voidHandler }
         set { _voidHandler = newValue }
     }
-    public private(set) var hasDotSetCallCount = 0
-    public var hasDot: ModuleX.SomeType? = nil { didSet { hasDotSetCallCount += 1 } }
 
-    public static private(set) var someValSetCallCount = 0
-    static private var _someVal: String = "" { didSet { someValSetCallCount += 1 } }
+    public var hasDot: ModuleX.SomeType? = nil
+
+
+    static private var _someVal: String = ""
     public static var someVal: String {
         get { return _someVal }
         set { _someVal = newValue }

--- a/Tests/TestVars/FixtureNonSimpleVars.swift
+++ b/Tests/TestVars/FixtureNonSimpleVars.swift
@@ -13,6 +13,7 @@ public protocol NonSimpleVars {
     var voidHandler: (() -> ()) { get }
     var hasDot: ModuleX.SomeType? { get }
     static var someVal: String { get }
+    static var someVal2: String { get set }
 }
 """
 
@@ -41,11 +42,10 @@ public class NonSimpleVarsMock: NonSimpleVars {
     public var hasDot: ModuleX.SomeType? = nil
 
 
-    static private var _someVal: String = ""
-    public static var someVal: String {
-        get { return _someVal }
-        set { _someVal = newValue }
-    }
+    public static var someVal: String = ""
+
+    public static private(set) var someVal2SetCallCount = 0
+    public static var someVal2: String = "" { didSet { someVal2SetCallCount += 1 } }
 }
 
 """

--- a/Tests/TestVars/VarTests.swift
+++ b/Tests/TestVars/VarTests.swift
@@ -23,4 +23,9 @@ class VarTests: MockoloTestCase {
                dstContent: simpleVarsAllowCallCountMock,
                allowSetCallCount: true)
     }
+
+    func testAsyncThrows() {
+        verify(srcContent: asyncThrowsVars,
+               dstContent: asyncThrowsVarsMock)
+    }
 }

--- a/Tests/TestVars/VarTests.swift
+++ b/Tests/TestVars/VarTests.swift
@@ -28,4 +28,9 @@ class VarTests: MockoloTestCase {
         verify(srcContent: asyncThrowsVars,
                dstContent: asyncThrowsVarsMock)
     }
+
+    func testThrowsNever() {
+        verify(srcContent: throwsNeverVars,
+               dstContent: throwsNeverVarsMock)
+    }
 }


### PR DESCRIPTION
- https://github.com/uber/mockolo/issues/210

## Main feature

Supported `{ get async throws }`.

```swift
/// @mockable
protocol AsyncThrowsVars {
    var getAndThrows: MyValue { get throws }
    var getAndAsync: MyValue { get async }
    var getAndAsyncAndThrows: Int { get async throws(any Error) }
}
```

- Generated

```swift
class AsyncThrowsVarsMock: AsyncThrowsVars {
    init() { }
    init(getAndThrows: MyValue, getAndAsync: MyValue, getAndAsyncAndThrows: Int = 0) {
        self.getAndThrowsHandler = { getAndThrows }
        self.getAndAsyncHandler = { getAndAsync }
        self.getAndAsyncAndThrowsHandler = { getAndAsyncAndThrows }
    }


    var getAndThrowsHandler: (() throws -> MyValue)?
    var getAndThrows: MyValue {
        get throws {
            if let getAndThrowsHandler = getAndThrowsHandler {
                return try getAndThrowsHandler()
            }
            fatalError("getAndThrowsHandler returns can't have a default value thus its handler must be set")
        }
    }

    var getAndAsyncHandler: (() async -> MyValue)?
    var getAndAsync: MyValue {
        get async {
            if let getAndAsyncHandler = getAndAsyncHandler {
                return await getAndAsyncHandler()
            }
            fatalError("getAndAsyncHandler returns can't have a default value thus its handler must be set")
        }
    }

    var getAndAsyncAndThrowsHandler: (() async throws(any Error) -> Int)?
    var getAndAsyncAndThrows: Int {
        get async throws(any Error) {
            if let getAndAsyncAndThrowsHandler = getAndAsyncAndThrowsHandler {
                return try await getAndAsyncAndThrowsHandler()
            }
            return 0
        }
    }
}
```

## Side effects

- For `var foo: Int { get }`, since the value is never set through original protocol, the call count has been removed.
