### PR TITLE
Organize the arguments of Model.render.

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -33,17 +33,23 @@ final class ArgumentsHistoryModel: Model {
         return force || isHistoryAnnotated
     }
     
-    func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool, disableCombineDefaultValues: Bool = false) -> String? {
-        guard enable(force: enableFuncArgsHistory) else {
+    func render(
+        context: RenderContext,
+        arguments: GenerationArguments
+    ) -> String? {
+        guard enable(force: arguments.enableFuncArgsHistory) else {
+            return nil
+        }
+        guard let overloadingResolvedName = context.overloadingResolvedName else {
             return nil
         }
         
         switch capturableParamNames.count {
         case 1:
-            return "\(identifier)\(String.argsHistorySuffix).append(\(capturableParamNames[0]))"
+            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append(\(capturableParamNames[0]))"
         case 2...:
             let paramNamesStr = capturableParamNames.joined(separator: ", ")
-            return "\(identifier)\(String.argsHistorySuffix).append((\(paramNamesStr)))"
+            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append((\(paramNamesStr)))"
         default:
             fatalError("paramNames must not be empty.")
         }

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -42,14 +42,14 @@ final class ClosureModel: Model {
         self.funcReturnType = returnType
     }
 
-    func type(context: RenderContext) -> SwiftType {
+    func type(enclosingType: SwiftType) -> SwiftType {
         return SwiftType.toClosureType(
             params: paramTypes,
             typeParams: genericTypeNames,
             isAsync: isAsync,
             throwing: throwing,
             returnType: funcReturnType,
-            encloser: context.enclosingType!
+            encloser: enclosingType
         )
     }
 
@@ -57,10 +57,11 @@ final class ClosureModel: Model {
         context: RenderContext,
         arguments: GenerationArguments = .default
     ) -> String? {
-        guard let overloadingResolvedName = context.overloadingResolvedName else {
+        guard let overloadingResolvedName = context.overloadingResolvedName,
+              let enclosingType = context.enclosingType else {
             return nil
         }
-        return applyClosureTemplate(type: type(context: context),
+        return applyClosureTemplate(type: type(enclosingType: enclosingType),
                                     name: overloadingResolvedName + .handlerSuffix,
                                     paramVals: paramNames,
                                     paramTypes: paramTypes,

--- a/Sources/MockoloFramework/Models/IfMacroModel.swift
+++ b/Sources/MockoloFramework/Models/IfMacroModel.swift
@@ -35,7 +35,15 @@ final class IfMacroModel: Model {
         self.offset = offset
     }
     
-    func render(with identifier: String, encloser: String, useTemplateFunc: Bool, useMockObservable: Bool, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {
-        return applyMacroTemplate(name: name, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, disableCombineDefaultValues: disableCombineDefaultValues, entities: entities)
+    func render(
+        context: RenderContext,
+        arguments: GenerationArguments
+    ) -> String? {
+        return applyMacroTemplate(
+            name: name,
+            context: context,
+            arguments: arguments,
+            entities: entities
+        )
     }
 }

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -35,7 +35,6 @@ final class MethodModel: Model {
     let processed: Bool
     let modelDescription: String?
     let isStatic: Bool
-    let shouldOverride: Bool
     let isAsync: Bool
     let throwing: ThrowingKind
     let funcsWithArgsHistory: [String]
@@ -153,7 +152,6 @@ final class MethodModel: Model {
     init(name: String,
          typeName: String,
          kind: MethodKind,
-         encloserType: FindTargetDeclType,
          acl: String,
          genericTypeParams: [ParamModel],
          genericWhereClause: String?,
@@ -175,7 +173,6 @@ final class MethodModel: Model {
         self.length = length
         self.kind = kind
         self.isStatic = isStatic
-        self.shouldOverride = encloserType == .classType
         self.params = params
         self.genericTypeParams = genericTypeParams
         self.genericWhereClause = genericWhereClause

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -219,18 +219,13 @@ final class MethodModel: Model {
             return nil
         }
 
-        return applyMethodTemplate(name: name,
-                                   kind: kind,
+        guard let overloadingResolvedName = context.overloadingResolvedName else {
+            return nil
+        }
+
+        return applyMethodTemplate(overloadingResolvedName: overloadingResolvedName,
                                    arguments: arguments,
-                                   isStatic: isStatic,
-                                   customModifiers: customModifiers,
                                    isOverride: shouldOverride,
-                                   genericTypeParams: genericTypeParams,
-                                   genericWhereClause: genericWhereClause,
-                                   params: params,
-                                   returnType: returnType,
-                                   accessLevel: accessLevel,
-                                   argsHistory: argsHistory,
                                    handler: handler(),
                                    context: context)
     }

--- a/Sources/MockoloFramework/Models/Model.swift
+++ b/Sources/MockoloFramework/Models/Model.swift
@@ -27,6 +27,18 @@ public enum ModelType {
     case closure
 }
 
+enum NominalTypeDeclKind: String {
+    case `class`
+    case `actor`
+    case `protocol`
+}
+
+struct RenderContext {
+    var overloadingResolvedName: String?
+    var enclosingType: SwiftType?
+    var annotatedTypeKind: NominalTypeDeclKind?
+}
+
 /// Represents a model for an entity such as var, func, class, etc.
 protocol Model: AnyObject {
     /// Identifier
@@ -45,14 +57,9 @@ protocol Model: AnyObject {
     var offset: Int64 { get }
 
     /// Applies a corresponding template to this model to output mocks
-    func render(with identifier: String,
-                encloser: String,
-                useTemplateFunc: Bool,
-                useMockObservable: Bool,
-                allowSetCallCount: Bool,
-                mockFinal: Bool,
-                enableFuncArgsHistory: Bool,
-                disableCombineDefaultValues: Bool
+    func render(
+        context: RenderContext,
+        arguments: GenerationArguments
     ) -> String?
 
     /// Used to differentiate multiple entities with the same name

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -15,11 +15,6 @@
 //
 
 final class NominalModel: Model {
-    enum NominalTypeDeclKind: String {
-        case `class`
-        case `actor`
-    }
-
     let namespaces: [String]
     let name: String
     let offset: Int64
@@ -27,7 +22,7 @@ final class NominalModel: Model {
     let attribute: String
     let accessLevel: String
     let identifier: String
-    let declTypeOfMockAnnotatedBaseType: DeclType
+    let declKindOfMockAnnotatedBaseType: NominalTypeDeclKind
     let inheritedTypes: [String]
     let entities: [(String, Model)]
     let initParamCandidates: [VariableModel]
@@ -42,7 +37,7 @@ final class NominalModel: Model {
     init(identifier: String,
          namespaces: [String],
          acl: String,
-         declTypeOfMockAnnotatedBaseType: DeclType,
+         declKindOfMockAnnotatedBaseType: NominalTypeDeclKind,
          declKind: NominalTypeDeclKind,
          inheritedTypes: [String],
          attributes: [String],
@@ -55,7 +50,7 @@ final class NominalModel: Model {
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
         self.type = SwiftType(self.name)
         self.namespaces = namespaces
-        self.declTypeOfMockAnnotatedBaseType = declTypeOfMockAnnotatedBaseType
+        self.declKindOfMockAnnotatedBaseType = declKindOfMockAnnotatedBaseType
         self.declKind = declKind
         self.inheritedTypes = inheritedTypes
         self.entities = entities
@@ -68,29 +63,17 @@ final class NominalModel: Model {
     }
     
     func render(
-        with identifier: String,
-        encloser: String,
-        useTemplateFunc: Bool,
-        useMockObservable: Bool,
-        allowSetCallCount: Bool = false,
-        mockFinal: Bool = false,
-        enableFuncArgsHistory: Bool = false,
-        disableCombineDefaultValues: Bool = false
+        context: RenderContext,
+        arguments: GenerationArguments
     ) -> String? {
         return applyNominalTemplate(
             name: name,
             identifier: self.identifier,
             accessLevel: accessLevel,
             attribute: attribute,
-            declTypeOfMockAnnotatedBaseType: declTypeOfMockAnnotatedBaseType,
             inheritedTypes: inheritedTypes,
             metadata: metadata,
-            useTemplateFunc: useTemplateFunc,
-            useMockObservable: useMockObservable,
-            allowSetCallCount: allowSetCallCount,
-            mockFinal: mockFinal,
-            enableFuncArgsHistory: enableFuncArgsHistory,
-            disableCombineDefaultValues: disableCombineDefaultValues,
+            arguments: arguments,
             initParamCandidates: initParamCandidates,
             declaredInits: declaredInits,
             entities: entities

--- a/Sources/MockoloFramework/Models/ParamModel.swift
+++ b/Sources/MockoloFramework/Models/ParamModel.swift
@@ -83,7 +83,10 @@ final class ParamModel: Model {
         return nil
     }
     
-    func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, allowSetCallCount: Bool = false, mockFinal: Bool = false,  enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {
+    func render(
+        context: RenderContext = .init(),
+        arguments: GenerationArguments = .default
+    ) -> String? {
         return applyParamTemplate(name: name, label: label, type: type, inInit: inInit)
     }
 }

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -146,10 +146,10 @@ public typealias ImportMap = [String: [String: [String]]]
 
 /// Metadata for a type being mocked
 public final class Entity {
-    var filepath: String = ""
     let entityNode: EntityNode
-    let isProcessed: Bool
+    let filepath: String
     let metadata: AnnotationMetadata?
+    let isProcessed: Bool
 
     var isAnnotated: Bool {
         return metadata != nil
@@ -164,16 +164,14 @@ public final class Entity {
 
         guard !isPrivate, !isFinal else {return nil}
 
-        let node = Entity(entityNode: entityNode,
-                          filepath: filepath,
-                          metadata: metadata,
-                          isProcessed: processed)
-
-        return node
+        return Entity(entityNode: entityNode,
+                      filepath: filepath,
+                      metadata: metadata,
+                      isProcessed: processed)
     }
 
     init(entityNode: EntityNode,
-         filepath: String = "",
+         filepath: String,
          metadata: AnnotationMetadata?,
          isProcessed: Bool) {
         self.entityNode = entityNode

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -61,7 +61,7 @@ struct ResolvedEntity {
         return NominalModel(identifier: key,
                             namespaces: entity.entityNode.namespaces,
                             acl: entity.entityNode.accessLevel,
-                            declTypeOfMockAnnotatedBaseType: entity.entityNode.declType,
+                            declKindOfMockAnnotatedBaseType: entity.entityNode.declKind,
                             declKind: inheritsActorProtocol ? .actor : .class,
                             inheritedTypes: inheritedTypes,
                             attributes: attributes,
@@ -84,22 +84,17 @@ protocol EntityNode {
     var mayHaveGlobalActor: Bool { get }
     var accessLevel: String { get }
     var attributesDescription: String { get }
-    var declType: DeclType { get }
+    var declKind: NominalTypeDeclKind { get }
     var inheritedTypes: [String] { get }
     var offset: Int64 { get }
     var hasBlankInit: Bool { get }
-    func subContainer(metadata: AnnotationMetadata?, declType: DeclType, path: String?, isProcessed: Bool) -> EntityNodeSubContainer
+    func subContainer(metadata: AnnotationMetadata?, declType: FindTargetDeclType, path: String?, isProcessed: Bool) -> EntityNodeSubContainer
 }
 
-final class EntityNodeSubContainer {
-    let attributes: [String]
-    let members: [Model]
-    let hasInit: Bool
-    init(attributes: [String], members: [Model], hasInit: Bool) {
-        self.attributes = attributes
-        self.members = members
-        self.hasInit = hasInit
-    }
+struct EntityNodeSubContainer {
+    var attributes: [String]
+    var members: [Model]
+    var hasInit: Bool
 }
 
 public enum CombineType {
@@ -129,6 +124,23 @@ struct AnnotationMetadata {
     var funcsWithArgsHistory: [String]?
     var modifiers: [String: Modifier]?
     var combineTypes: [String: CombineType]?
+}
+
+struct GenerationArguments {
+    var useTemplateFunc: Bool
+    var useMockObservable: Bool
+    var allowSetCallCount: Bool
+    var mockFinal: Bool
+    var enableFuncArgsHistory: Bool
+    var disableCombineDefaultValues: Bool
+    static let `default` = GenerationArguments(
+        useTemplateFunc: false,
+        useMockObservable: false,
+        allowSetCallCount: false,
+        mockFinal: false,
+        enableFuncArgsHistory: false,
+        disableCombineDefaultValues: false
+    )
 }
 
 public typealias ImportMap = [String: [String: [String]]]

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -14,15 +14,15 @@
 //  limitations under the License.
 //
 
-import Foundation
+import Algorithms
 
 /// Metadata containing unique models and potential init params ready to be rendered for output
 struct ResolvedEntity {
-    let key: String
-    let entity: Entity
-    let uniqueModels: [(String, Model)]
-    let attributes: [String]
-    let inheritedTypes: [String]
+    var key: String
+    var entity: Entity
+    var uniqueModels: [(String, Model)]
+    var attributes: [String]
+    var inheritedTypes: [String]
     var inheritsActorProtocol: Bool
 
     var declaredInits: [MethodModel] {
@@ -44,8 +44,7 @@ struct ResolvedEntity {
     ///             processed (already mocked by a previous run if any) models.
     /// @returns A list of init parameter models
     private func sortedInitVars(`in` models: [VariableModel]) -> [VariableModel] {
-        let processed = models.filter {$0.processed && $0.canBeInitParam}
-        let unprocessed = models.filter {!$0.processed && $0.canBeInitParam}
+        let (unprocessed, processed) = models.filter(\.canBeInitParam).partitioned(by: \.processed)
 
         // Named params in init should be unique. Add a duplicate param check to ensure it.
         let curVarsSorted = unprocessed.sorted(path: \.offset, fallback: \.name)
@@ -74,8 +73,8 @@ struct ResolvedEntity {
 }
 
 struct ResolvedEntityContainer {
-    let entity: ResolvedEntity
-    let paths: [String]
+    var entity: ResolvedEntity
+    var paths: [String]
 }
 
 protocol EntityNode {

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -87,7 +87,7 @@ protocol EntityNode {
     var inheritedTypes: [String] { get }
     var offset: Int64 { get }
     var hasBlankInit: Bool { get }
-    func subContainer(metadata: AnnotationMetadata?, declType: FindTargetDeclType, path: String?, isProcessed: Bool) -> EntityNodeSubContainer
+    func subContainer(metadata: AnnotationMetadata?, declKind: NominalTypeDeclKind, path: String?, isProcessed: Bool) -> EntityNodeSubContainer
 }
 
 struct EntityNodeSubContainer {

--- a/Sources/MockoloFramework/Models/TypeAliasModel.swift
+++ b/Sources/MockoloFramework/Models/TypeAliasModel.swift
@@ -32,7 +32,7 @@ final class TypeAliasModel: Model {
         return .typeAlias
     }
 
-    init(name: String, typeName: String, acl: String?, encloserType: DeclType, overrideTypes: [String: String]?, offset: Int64, length: Int64, modelDescription: String?, useDescription: Bool = false, processed: Bool) {
+    init(name: String, typeName: String, acl: String?, encloserType: FindTargetDeclType, overrideTypes: [String: String]?, offset: Int64, length: Int64, modelDescription: String?, useDescription: Bool = false, processed: Bool) {
         self.name = name
         self.accessLevel = acl ?? ""
         self.offset = offset
@@ -58,7 +58,10 @@ final class TypeAliasModel: Model {
         return fullName
     }
     
-    func render(with identifier: String, encloser: String, useTemplateFunc: Bool = false, useMockObservable: Bool = false, allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, disableCombineDefaultValues: Bool = false) -> String? {
+    func render(
+        context: RenderContext,
+        arguments: GenerationArguments
+    ) -> String? {
         if processed || useDescription, let modelDescription = modelDescription?.trimmingCharacters(in: .whitespacesAndNewlines) {
             if addAcl {
                 return "\(1.tab)\(accessLevel) \(modelDescription)"

--- a/Sources/MockoloFramework/Models/TypeAliasModel.swift
+++ b/Sources/MockoloFramework/Models/TypeAliasModel.swift
@@ -26,13 +26,12 @@ final class TypeAliasModel: Model {
     let useDescription: Bool
     let modelDescription: String?
     let overrideTypes: [String: String]?
-    let addAcl: Bool
 
     var modelType: ModelType {
         return .typeAlias
     }
 
-    init(name: String, typeName: String, acl: String?, encloserType: FindTargetDeclType, overrideTypes: [String: String]?, offset: Int64, length: Int64, modelDescription: String?, useDescription: Bool = false, processed: Bool) {
+    init(name: String, typeName: String, acl: String?, overrideTypes: [String: String]?, offset: Int64, length: Int64, modelDescription: String?, useDescription: Bool = false, processed: Bool) {
         self.name = name
         self.accessLevel = acl ?? ""
         self.offset = offset
@@ -41,7 +40,6 @@ final class TypeAliasModel: Model {
         self.modelDescription = modelDescription
         self.overrideTypes = overrideTypes
         self.useDescription = useDescription
-        self.addAcl = encloserType == .protocolType && !processed
         // If there's an override typealias value, set it to type
         if let val = overrideTypes?[self.name] {
             self.type  = SwiftType(val)
@@ -53,15 +51,16 @@ final class TypeAliasModel: Model {
     var fullName: String {
         return self.name + self.type.displayName
     }
-    
+
     func name(by level: Int) -> String {
         return fullName
     }
-    
+
     func render(
         context: RenderContext,
         arguments: GenerationArguments
     ) -> String? {
+        let addAcl = context.annotatedTypeKind == .protocol && !processed
         if processed || useDescription, let modelDescription = modelDescription?.trimmingCharacters(in: .whitespacesAndNewlines) {
             if addAcl {
                 return "\(1.tab)\(accessLevel) \(modelDescription)"

--- a/Sources/MockoloFramework/Models/TypeAliasModel.swift
+++ b/Sources/MockoloFramework/Models/TypeAliasModel.swift
@@ -58,7 +58,7 @@ final class TypeAliasModel: Model {
 
     func render(
         context: RenderContext,
-        arguments: GenerationArguments
+        arguments: GenerationArguments = .default
     ) -> String? {
         let addAcl = context.annotatedTypeKind == .protocol && !processed
         if processed || useDescription, let modelDescription = modelDescription?.trimmingCharacters(in: .whitespacesAndNewlines) {

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -17,12 +17,10 @@ final class VariableModel: Model {
     let offset: Int64
     let accessLevel: String
     let attributes: [String]?
-    let encloserType: FindTargetDeclType
     /// Indicates whether this model can be used as a parameter to an initializer
     let canBeInitParam: Bool
     let processed: Bool
     let isStatic: Bool
-    let shouldOverride: Bool
     let storageKind: MockStorageKind
     let rxTypes: [String: String]?
     let customModifiers: [String: Modifier]?
@@ -50,7 +48,6 @@ final class VariableModel: Model {
     init(name: String,
          type: SwiftType,
          acl: String?,
-         encloserType: FindTargetDeclType,
          isStatic: Bool,
          storageKind: MockStorageKind,
          canBeInitParam: Bool,
@@ -65,14 +62,12 @@ final class VariableModel: Model {
         self.offset = offset
         self.isStatic = isStatic
         self.storageKind = storageKind
-        self.shouldOverride = encloserType == .classType
         self.canBeInitParam = canBeInitParam
         self.processed = processed
         self.rxTypes = rxTypes
         self.customModifiers = customModifiers
         self.accessLevel = acl ?? ""
         self.attributes = nil
-        self.encloserType = encloserType
         self.modelDescription = modelDescription
         self.combineType = combineType
     }
@@ -84,6 +79,7 @@ final class VariableModel: Model {
         guard let enclosingType = context.enclosingType else {
             return nil
         }
+        let shouldOverride = context.annotatedTypeKind == .class
         if processed {
             guard let modelDescription = modelDescription?.trimmingCharacters(in: .newlines), !modelDescription.isEmpty else {
                 return nil

--- a/Sources/MockoloFramework/Operations/Generator.swift
+++ b/Sources/MockoloFramework/Operations/Generator.swift
@@ -31,7 +31,7 @@ public func generate(sourceDirs: [String],
                      annotation: String,
                      header: String?,
                      macro: String?,
-                     declType: DeclType,
+                     declType: FindTargetDeclType,
                      useTemplateFunc: Bool,
                      useMockObservable: Bool,
                      allowSetCallCount: Bool,
@@ -137,13 +137,16 @@ public func generate(sourceDirs: [String],
     
     signpost_begin(name: "Render models")
     log("Render models with templates...", level: .info)
-    renderTemplates(entities: resolvedEntities,
-                    useTemplateFunc: useTemplateFunc,
-                    useMockObservable: useMockObservable,
-                    allowSetCallCount: allowSetCallCount,
-                    mockFinal: mockFinal,
-                    enableFuncArgsHistory: enableFuncArgsHistory,
-                    disableCombineDefaultValues: disableCombineDefaultValues
+    renderTemplates(
+        entities: resolvedEntities,
+        arguments: .init(
+            useTemplateFunc: useTemplateFunc,
+            useMockObservable: useMockObservable,
+            allowSetCallCount: allowSetCallCount,
+            mockFinal: mockFinal,
+            enableFuncArgsHistory: enableFuncArgsHistory,
+            disableCombineDefaultValues: disableCombineDefaultValues
+        )
     ) { (mockString: String, offset: Int64) in
                         candidates.append((mockString, offset))
     }

--- a/Sources/MockoloFramework/Operations/ImportsHandler.swift
+++ b/Sources/MockoloFramework/Operations/ImportsHandler.swift
@@ -1,11 +1,20 @@
 //
-//  ImportsHandler.swift
-//  MockoloFramework
+//  Copyright (c) 2018. Uber Technologies
 //
-//  Created by Ellie on 4/8/20.
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
 //
 
-import Foundation
+import Algorithms
 
 func handleImports(pathToImportsMap: ImportMap,
                    customImports: [String]?,
@@ -46,8 +55,8 @@ func handleImports(pathToImportsMap: ImportMap,
 
     if let existingSet = sortedImports[defaultKey] {
         if let testableImports = testableImports {
-            let nonTestableInList = existingSet.filter { !testableImports.contains($0.moduleNameInImport) }.map{$0}
-            let testableInList = existingSet.filter { testableImports.contains($0.moduleNameInImport) }.map{ "@testable " + $0 }
+            let (nonTestableInList, rawTestableInList) = existingSet.partitioned(by: { testableImports.contains($0.moduleNameInImport) })
+            let testableInList = rawTestableInList.map{ "@testable " + $0 }
             let remainingTestable = testableImports.filter { !testableInList.contains($0) }.map {$0.asTestableImport}
             let testable = Set([testableInList, remainingTestable].flatMap{$0}).sorted()
             sortedImports[defaultKey] = [nonTestableInList, testable].flatMap{$0}

--- a/Sources/MockoloFramework/Operations/TemplateRenderer.swift
+++ b/Sources/MockoloFramework/Operations/TemplateRenderer.swift
@@ -19,20 +19,17 @@ import Foundation
 /// Renders models with templates for output
 
 func renderTemplates(entities: [ResolvedEntity],
-                     useTemplateFunc: Bool,
-                     useMockObservable: Bool,
-                     allowSetCallCount: Bool,
-                     mockFinal: Bool,
-                     enableFuncArgsHistory: Bool,
-                     disableCombineDefaultValues: Bool,
+                     arguments: GenerationArguments,
                      completion: @escaping (String, Int64) -> ()) {
     scan(entities) { (resolvedEntity, lock) in
         let mockModel = resolvedEntity.model()
-        if let mockString = mockModel.render(with: resolvedEntity.key, encloser: mockModel.name, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, disableCombineDefaultValues: disableCombineDefaultValues), !mockString.isEmpty {
+        if let mockString = mockModel.render(
+            context: .init(),
+            arguments: arguments
+        ), !mockString.isEmpty {
             lock?.lock()
             completion(mockString, mockModel.offset)
             lock?.unlock()
         }
     }
 }
-

--- a/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
+++ b/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
@@ -34,17 +34,7 @@ private func generateUniqueModels(key: String,
                                   entity: Entity,
                                   protocolMap: [String: Entity],
                                   inheritanceMap: [String: Entity]) -> ResolvedEntityContainer {
-    let declType: FindTargetDeclType = {
-        switch entity.entityNode.declKind {
-        case .class:
-            return .classType
-        case .actor:
-            return .other
-        case .protocol:
-            return .protocolType
-        }
-    }()
-    let (models, processedModels, attributes, inheritedTypes, paths) = lookupEntities(key: key, declType: declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
+    let (models, processedModels, attributes, inheritedTypes, paths) = lookupEntities(key: key, declKind: entity.entityNode.declKind, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
 
     let processedFullNames = processedModels.compactMap {$0.fullName}
 

--- a/Sources/MockoloFramework/Parsers/SourceParser.swift
+++ b/Sources/MockoloFramework/Parsers/SourceParser.swift
@@ -18,7 +18,7 @@ import Foundation
 import SwiftSyntax
 import SwiftParser
 
-public enum DeclType {
+public enum FindTargetDeclType {
     case protocolType, classType, other, all
 }
 
@@ -48,7 +48,7 @@ public class SourceParser {
                            exclusionSuffixes: [String],
                            annotation: String,
                            fileMacro: String?,
-                           declType: DeclType,
+                           declType: FindTargetDeclType,
                            completion: @escaping ([Entity], ImportMap?) -> ()) {
 
         guard !paths.isEmpty else { return }
@@ -67,7 +67,7 @@ public class SourceParser {
                               exclusionSuffixes: [String] = [],
                               annotation: String,
                               fileMacro: String?,
-                              declType: DeclType,
+                              declType: FindTargetDeclType,
                               lock: NSLock?,
                               completion: @escaping ([Entity], ImportMap?) -> ()) {
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -158,7 +158,7 @@ extension MemberBlockItemSyntax {
         if let varMember = self.decl.as(VariableDeclSyntax.self) {
             if validateMember(varMember.modifiers, declType, processed: processed) {
                 let acl = memberAcl(varMember.modifiers, encloserAcl, declType)
-                if let item = varMember.models(with: acl, declType: declType, metadata: metadata, processed: processed).first {
+                if let item = varMember.models(with: acl, metadata: metadata, processed: processed).first {
                     return (item, varMember.attributes.trimmedDescription, false)
                 }
             }
@@ -403,7 +403,7 @@ extension AttributeListSyntax {
 }
 
 extension VariableDeclSyntax {
-    func models(with acl: String, declType: FindTargetDeclType, metadata: AnnotationMetadata?, processed: Bool) -> [Model] {
+    func models(with acl: String, metadata: AnnotationMetadata?, processed: Bool) -> [Model] {
         // Detect whether it's static
         let isStatic = self.modifiers.isStatic
 
@@ -454,7 +454,6 @@ extension VariableDeclSyntax {
             return VariableModel(name: name,
                                  type: SwiftType(typeName),
                                  acl: acl,
-                                 encloserType: declType,
                                  isStatic: isStatic,
                                  storageKind: storageKind,
                                  canBeInitParam: potentialInitParam,
@@ -480,7 +479,6 @@ extension SubscriptDeclSyntax {
         let subscriptModel = MethodModel(name: self.subscriptKeyword.text,
                                          typeName: self.returnClause.type.description,
                                          kind: .subscriptKind,
-                                         encloserType: declType,
                                          acl: acl,
                                          genericTypeParams: genericTypeParams,
                                          genericWhereClause: genericWhereClause,
@@ -510,7 +508,6 @@ extension FunctionDeclSyntax {
         let funcmodel = MethodModel(name: self.name.description,
                                     typeName: self.signature.returnClause?.type.description ?? "",
                                     kind: .funcKind,
-                                    encloserType: declType,
                                     acl: acl,
                                     genericTypeParams: genericTypeParams,
                                     genericWhereClause: genericWhereClause,
@@ -551,7 +548,6 @@ extension InitializerDeclSyntax {
         return MethodModel(name: "init",
                            typeName: "",
                            kind: .initKind(required: requiredInit, override: declType == .classType),
-                           encloserType: declType,
                            acl: acl,
                            genericTypeParams: genericTypeParams,
                            genericWhereClause: genericWhereClause,

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -17,7 +17,8 @@
 import Foundation
 
 extension ClosureModel {
-    func applyClosureTemplate(name: String,
+    func applyClosureTemplate(type: SwiftType,
+                              name: String,
                               paramVals: [String]?,
                               paramTypes: [SwiftType]?,
                               returnDefaultType: SwiftType) -> String {

--- a/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
+++ b/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
@@ -18,15 +18,20 @@ import Foundation
 
 extension IfMacroModel {
     func applyMacroTemplate(name: String,
-                            useTemplateFunc: Bool,
-                            useMockObservable: Bool,
-                            allowSetCallCount: Bool,
-                            mockFinal: Bool,
-                            enableFuncArgsHistory: Bool,
-                            disableCombineDefaultValues: Bool,
+                            context: RenderContext,
+                            arguments: GenerationArguments,
                             entities: [Model]) -> String {
         let rendered = entities
-            .compactMap {$0.render(with: $0.name, encloser: "", useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, allowSetCallCount: allowSetCallCount,  mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, disableCombineDefaultValues: disableCombineDefaultValues) }
+            .compactMap { model in
+                model.render(
+                    context: .init(
+                        overloadingResolvedName: model.name, // FIXME: the name is not resolving overload
+                        enclosingType: context.enclosingType,
+                        annotatedTypeKind: context.annotatedTypeKind
+                    ),
+                    arguments: arguments
+                )
+            }
             .joined(separator: "\n")
         
         let template = """

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -17,23 +17,11 @@
 import Foundation
 
 extension MethodModel {
-    func applyMethodTemplate(name: String,
-                             kind: MethodKind,
+    func applyMethodTemplate(overloadingResolvedName: String,
                              arguments: GenerationArguments,
-                             isStatic: Bool,
-                             customModifiers: [String: Modifier]?,
                              isOverride: Bool,
-                             genericTypeParams: [ParamModel],
-                             genericWhereClause: String?,
-                             params: [ParamModel],
-                             returnType: SwiftType,
-                             accessLevel: String,
-                             argsHistory: ArgumentsHistoryModel?,
                              handler: ClosureModel?,
                              context: RenderContext) -> String {
-        guard let overloadingResolvedName = context.overloadingResolvedName else {
-            preconditionFailure("context broken")
-        }
         var template = ""
 
         let returnTypeName = returnType.isUnknown ? "" : returnType.typeName
@@ -122,8 +110,7 @@ extension MethodModel {
 
             let overrideStr = isOverride ? "\(String.override) " : ""
             let modifierTypeStr: String
-            if let customModifiers = customModifiers,
-            let customModifier: Modifier = customModifiers[name] {
+            if let customModifier: Modifier = customModifiers[name] {
                 modifierTypeStr = customModifier.rawValue + " "
             } else {
                 modifierTypeStr = ""

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -37,11 +37,11 @@ extension MethodModel {
             return ""
         default:
 
-            guard let handler else { return "" }
+            guard let handler, let enclosingType = context.enclosingType else { return "" }
 
             let callCount = "\(overloadingResolvedName)\(String.callCountSuffix)"
             let handlerVarName = "\(overloadingResolvedName)\(String.handlerSuffix)"
-            let handlerVarType = handler.type(context: context).typeName // ?? "Any"
+            let handlerVarType = handler.type(enclosingType: enclosingType).typeName // ?? "Any"
             let handlerReturn = handler.render(context: context) ?? ""
 
             let suffixStr = applyFunctionSuffixTemplate(
@@ -54,7 +54,7 @@ extension MethodModel {
             var body = ""
 
             if arguments.useTemplateFunc {
-                let callMockFunc = !throwing.hasError && (handler.type(context: context).cast?.isEmpty ?? false)
+                let callMockFunc = !throwing.hasError && (handler.type(enclosingType: enclosingType).cast?.isEmpty ?? false)
                 if callMockFunc {
                     let handlerParamValsStr = params.map { (arg) -> String in
                         if arg.type.typeName.hasPrefix(String.autoclosure) {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -135,8 +135,8 @@ extension NominalModel {
                     } else {
                         let list = paramList.sorted(path: \.fullName, fallback: \.name)
                         if list.count > 0, list.count == buffer.count {
-                            let dups = zip(list, buffer).filter {$0.0.fullName == $0.1.fullName}
-                            if !dups.isEmpty {
+                            let hasDuplicates = zip(list, buffer).contains(where: { $0.fullName == $1.fullName })
+                            if hasDuplicates {
                                 needParamedInit = false
                             }
                         }

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -21,15 +21,9 @@ extension NominalModel {
                               identifier: String,
                               accessLevel: String,
                               attribute: String,
-                              declTypeOfMockAnnotatedBaseType: DeclType,
                               inheritedTypes: [String],
                               metadata: AnnotationMetadata?,
-                              useTemplateFunc: Bool,
-                              useMockObservable: Bool,
-                              allowSetCallCount: Bool,
-                              mockFinal: Bool,
-                              enableFuncArgsHistory: Bool,
-                              disableCombineDefaultValues: Bool,
+                              arguments: GenerationArguments,
                               initParamCandidates: [VariableModel],
                               declaredInits: [MethodModel],
                               entities: [(String, Model)]) -> String {
@@ -39,7 +33,7 @@ extension NominalModel {
         let acl = accessLevel.isEmpty ? "" : accessLevel + " "
         let typealiases = typealiasWhitelist(in: entities)
         let renderedEntities = entities
-            .compactMap { (uniqueId: String, model: Model) -> (String, Int64)? in
+            .compactMap { (uniqueId: String, model: Model) -> String? in
                 if model.modelType == .typeAlias, let _ = typealiases?[model.name] {
                     // this case will be handlded by typealiasWhitelist look up later
                     return nil
@@ -50,22 +44,22 @@ extension NominalModel {
                 if model.modelType == .method, let model = model as? MethodModel, model.isInitializer, !model.processed {
                     return nil
                 }
-                if let ret = model.render(with: uniqueId, encloser: name, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, disableCombineDefaultValues: disableCombineDefaultValues) {
-                    return (ret, model.offset)
+                if let ret = model.render(
+                    context: .init(
+                        overloadingResolvedName: uniqueId,
+                        enclosingType: type,
+                        annotatedTypeKind: declKindOfMockAnnotatedBaseType
+                    ),
+                    arguments: arguments
+                ) {
+                    return ret
                 }
                 return nil
-        }
-        .sorted { (left: (String, Int64), right: (String, Int64)) -> Bool in
-            if left.1 == right.1 {
-                return left.0 < right.0
             }
-            return left.1 < right.1
-        }
-        .map {$0.0}
-        .joined(separator: "\n")
+            .joined(separator: "\n")
         
         var typealiasTemplate = ""
-        let addAcl = declTypeOfMockAnnotatedBaseType == .protocolType ? acl : ""
+        let addAcl = declKindOfMockAnnotatedBaseType == .protocol ? acl : ""
         if let typealiasWhitelist = typealiases {
             typealiasTemplate = typealiasWhitelist.map { (arg: (key: String, value: [String])) -> String in
                 let joinedType = arg.value.sorted().joined(separator: " & ")
@@ -78,7 +72,7 @@ extension NominalModel {
             moduleDot = moduleName + "."
         }
         
-        let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits,  acl: acl, declTypeOfMockAnnotatedBaseType: declTypeOfMockAnnotatedBaseType, overrides: metadata?.varTypes)
+        let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits, acl: acl, declKindOfMockAnnotatedBaseType: declKindOfMockAnnotatedBaseType, overrides: metadata?.varTypes)
 
         var inheritedTypes = inheritedTypes
         inheritedTypes.insert("\(moduleDot)\(identifier)", at: 0)
@@ -94,7 +88,7 @@ extension NominalModel {
             body += "\(renderedEntities)"
         }
 
-        let finalStr = mockFinal ? "\(String.final) " : ""
+        let finalStr = arguments.mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
         \(acl)\(finalStr)\(declKind.rawValue) \(name): \(inheritedTypes.joined(separator: ", ")) {
@@ -117,7 +111,7 @@ extension NominalModel {
         initParamCandidates: [VariableModel],
         declaredInits: [MethodModel],
         acl: String,
-        declTypeOfMockAnnotatedBaseType: DeclType,
+        declKindOfMockAnnotatedBaseType: NominalTypeDeclKind,
         overrides: [String: String]?
     ) -> String {
         
@@ -130,7 +124,7 @@ extension NominalModel {
             needBlankInit = true
             needParamedInit = false
         } else {
-            if declTypeOfMockAnnotatedBaseType == .protocolType {
+            if declKindOfMockAnnotatedBaseType == .protocol {
                 needParamedInit = !initParamCandidates.isEmpty
                 needBlankInit = true
 
@@ -203,9 +197,9 @@ extension NominalModel {
             if case let .initKind(required, override) = m.kind, !m.processed {
                 let modifier = required ? "\(String.required) " : (override ? "\(String.override) " : "")
                 let mAcl = m.accessLevel.isEmpty ? "" : "\(m.accessLevel) "
-                let genericTypeDeclsStr = m.genericTypeParams.compactMap {$0.render(with: "", encloser: "")}.joined(separator: ", ")
+                let genericTypeDeclsStr = m.genericTypeParams.compactMap {$0.render()}.joined(separator: ", ")
                 let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
-                let paramDeclsStr = m.params.compactMap{$0.render(with: "", encloser: "")}.joined(separator: ", ")
+                let paramDeclsStr = m.params.compactMap{$0.render()}.joined(separator: ", ")
                 let suffixStr = applyFunctionSuffixTemplate(
                     isAsync: m.isAsync,
                     throwing: m.throwing

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -25,7 +25,8 @@ extension VariableModel {
                                customModifiers: [String: Modifier]?,
                                allowSetCallCount: Bool,
                                shouldOverride: Bool,
-                               accessLevel: String) -> String {
+                               accessLevel: String,
+                               context: RenderContext) -> String {
 
         let underlyingSetCallCount = "\(name)\(String.setCallCountSuffix)"
         let underlyingVarDefaultVal = type.defaultVal()
@@ -112,9 +113,12 @@ extension VariableModel {
                 paramTypes: [],
                 isAsync: effects.isAsync,
                 throwing: effects.throwing,
-                returnType: type,
-                encloser: ""
-            ).render(with: name, encloser: "") ?? "")
+                returnType: type
+            ).render(context: .init(
+                overloadingResolvedName: name, // var cannot overload. this is ok
+                enclosingType: context.enclosingType,
+                annotatedTypeKind: context.annotatedTypeKind
+            )) ?? "")
                 .addingIndent(1)
 
             return """

--- a/Sources/MockoloFramework/Utils/InheritanceResolver.swift
+++ b/Sources/MockoloFramework/Utils/InheritanceResolver.swift
@@ -25,7 +25,7 @@ import Algorithms
 /// @returns a list of models representing sub-entities of the current entity, a list of models processed in dependent mock files if exists,
 ///          cumulated attributes, cumulated inherited types, and a map of filepaths and file contents (used for import lines lookup later).
 func lookupEntities(key: String,
-                    declType: DeclType,
+                    declType: FindTargetDeclType,
                     protocolMap: [String: Entity],
                     inheritanceMap: [String: Entity]) -> ([Model], [Model], [String], Set<String>, [String]) {
 

--- a/Sources/MockoloFramework/Utils/InheritanceResolver.swift
+++ b/Sources/MockoloFramework/Utils/InheritanceResolver.swift
@@ -25,7 +25,7 @@ import Algorithms
 /// @returns a list of models representing sub-entities of the current entity, a list of models processed in dependent mock files if exists,
 ///          cumulated attributes, cumulated inherited types, and a map of filepaths and file contents (used for import lines lookup later).
 func lookupEntities(key: String,
-                    declType: FindTargetDeclType,
+                    declKind: NominalTypeDeclKind,
                     protocolMap: [String: Entity],
                     inheritanceMap: [String: Entity]) -> ([Model], [Model], [String], Set<String>, [String]) {
 
@@ -42,7 +42,7 @@ func lookupEntities(key: String,
 
     // Look up the mock entities of a protocol specified by the name.
     if let current = protocolMap[key] {
-        let sub = current.entityNode.subContainer(metadata: current.metadata, declType: declType, path: current.filepath, isProcessed: current.isProcessed)
+        let sub = current.entityNode.subContainer(metadata: current.metadata, declKind: declKind, path: current.filepath, isProcessed: current.isProcessed)
         models.append(contentsOf: sub.members)
         if !current.isProcessed {
             attributes.append(contentsOf: sub.attributes)
@@ -51,11 +51,11 @@ func lookupEntities(key: String,
         paths.append(current.filepath)
         
         
-        if declType == .protocolType { // TODO: remove this once parent protocol (current decl = classtype) handling is resolved.
+        if declKind == .protocol { // TODO: remove this once parent protocol (current decl = classtype) handling is resolved.
             // If the protocol inherits other protocols, look up their entities as well.
             for parent in current.entityNode.inheritedTypes {
                 if parent != .class, parent != .anyType, parent != .anyObject {
-                    let (parentModels, parentProcessedModels, parentAttributes, parentInheritedTypes, parentPaths) = lookupEntities(key: parent, declType: declType, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
+                    let (parentModels, parentProcessedModels, parentAttributes, parentInheritedTypes, parentPaths) = lookupEntities(key: parent, declKind: declKind, protocolMap: protocolMap, inheritanceMap: inheritanceMap)
                     models.append(contentsOf: parentModels)
                     processedModels.append(contentsOf: parentProcessedModels)
                     attributes.append(contentsOf: parentAttributes)
@@ -64,9 +64,9 @@ func lookupEntities(key: String,
                 }
             }
         }
-    } else if let parentMock = inheritanceMap["\(key)Mock"], declType == .protocolType {
+    } else if let parentMock = inheritanceMap["\(key)Mock"], declKind == .protocol {
         // If the parent protocol is not in the protocol map, look it up in the input parent mocks map.
-        let sub = parentMock.entityNode.subContainer(metadata: parentMock.metadata, declType: declType, path: parentMock.filepath, isProcessed: parentMock.isProcessed)
+        let sub = parentMock.entityNode.subContainer(metadata: parentMock.metadata, declKind: declKind, path: parentMock.filepath, isProcessed: parentMock.isProcessed)
         processedModels.append(contentsOf: sub.members)
         if !parentMock.isProcessed {
             attributes.append(contentsOf: sub.attributes)

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -518,7 +518,7 @@ public final class SwiftType {
         isAsync: Bool,
         throwing: ThrowingKind,
         returnType: SwiftType,
-        encloser: String
+        encloser: SwiftType
     ) -> SwiftType {
         let displayableParamTypes = params.map { (subtype: SwiftType) -> String in
             return subtype.processTypeParams(with: typeParams)
@@ -553,7 +553,7 @@ public final class SwiftType {
         }
 
          if returnType.isSelf {
-            displayableReturnType = encloser
+             displayableReturnType = encloser.typeName
             returnTypeCast = " as! " + String.`Self`
         }
 

--- a/Tests/MockoloTestCase.swift
+++ b/Tests/MockoloTestCase.swift
@@ -54,7 +54,7 @@ class MockoloTestCase: XCTestCase {
         }
     }
 
-    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false) {
+    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false) {
         let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
@@ -66,7 +66,7 @@ class MockoloTestCase: XCTestCase {
         try? verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues)
     }
     
-    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: DeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }) {
+    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }) {
         let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
@@ -82,7 +82,7 @@ class MockoloTestCase: XCTestCase {
         )
     }
 
-    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: DeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, dstFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool) throws {
+    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: FindTargetDeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, dstFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool) throws {
         var index = 0
         srcFilePathsCount = srcContents.count
         mockFilePathsCount = mockContents?.count ?? 0

--- a/Tests/TestMacros/FixtureMacro.swift
+++ b/Tests/TestMacros/FixtureMacro.swift
@@ -270,3 +270,39 @@ class PresentableListenerMock: PresentableListener {
 }
 
 """
+
+let macroInFuncWithOverload = """
+/// \(String.mockAnnotation)
+protocol PresentableListener: AnyObject {
+    #if DEBUG
+    func run(value: Int)
+    func run(value: String)
+    #endif
+}
+"""
+
+let macroInFuncWithOverloadMock = """
+class PresentableListenerMock: PresentableListener {
+    init() { }
+    #if DEBUG
+    private(set) var runCallCount = 0
+    var runHandler: ((Int)  -> ())?
+    func run(value: Int)   {
+        runCallCount += 1
+        if let runHandler = runHandler {
+            runHandler(value)
+        }
+        
+    }
+    private(set) var runValueCallCount = 0
+    var runValueHandler: ((String)  -> ())?
+    func run(value: String)   {
+        runValueCallCount += 1
+        if let runValueHandler = runValueHandler {
+            runValueHandler(value)
+        }
+        
+    }
+    #endif
+}
+"""

--- a/Tests/TestMacros/MacroTests.swift
+++ b/Tests/TestMacros/MacroTests.swift
@@ -1,35 +1,42 @@
-import Foundation
+import XCTest
 
-class MacroTests: MockoloTestCase {
-   func testMacroInFunc() {
+final class MacroTests: MockoloTestCase {
+    func testMacroInFunc() {
         verify(srcContent: macroInFunc,
                dstContent: macroInFuncMock)
     }
 
-    func testMacroImports() {
-         verify(srcContent: macroImports,
-                dstContent: macroImportsMock)
+    func testMacroInFuncWithOverload() {
+        XCTExpectFailure("Resolving overloading in #if is broken.") {
+            verify(srcContent: macroInFuncWithOverload,
+                   dstContent: macroInFuncWithOverloadMock)
+        }
     }
-    
+
+    func testMacroImports() {
+        verify(srcContent: macroImports,
+               dstContent: macroImportsMock)
+    }
+
     func testMacroImportsWithOtherMacro() {
-         verify(srcContent: macroImports,
-                mockContent: parentMock,
-                dstContent: macroImportsWithParentMock)
+        verify(srcContent: macroImports,
+               mockContent: parentMock,
+               dstContent: macroImportsWithParentMock)
     }
 
     func testInheritedMacroImports() {
-         verify(srcContent: macroImports,
-                mockContent: parentWithMacroMock,
-                dstContent: inheritedMacroImportsMock)
+        verify(srcContent: macroImports,
+               mockContent: parentWithMacroMock,
+               dstContent: inheritedMacroImportsMock)
     }
 
     func testIfElseMacroImports() {
-         verify(srcContent: ifElseMacroImports,
-                dstContent: ifElseMacroImportsMock)
+        verify(srcContent: ifElseMacroImports,
+               dstContent: ifElseMacroImportsMock)
     }
 
     func testNestedMacroImports() {
-         verify(srcContent: nestedMacroImports,
-                dstContent: nestedMacroImportsMock)
+        verify(srcContent: nestedMacroImports,
+               dstContent: nestedMacroImportsMock)
     }
 }

--- a/Tests/TestMacros/MacroTests.swift
+++ b/Tests/TestMacros/MacroTests.swift
@@ -6,12 +6,14 @@ final class MacroTests: MockoloTestCase {
                dstContent: macroInFuncMock)
     }
 
+#if os(macOS)
     func testMacroInFuncWithOverload() {
         XCTExpectFailure("Resolving overloading in #if is broken.") {
             verify(srcContent: macroInFuncWithOverload,
                    dstContent: macroInFuncWithOverloadMock)
         }
     }
+#endif
 
     func testMacroImports() {
         verify(srcContent: macroImports,


### PR DESCRIPTION
`Model.render` has a lot of arguments, making it very complex.
There are also places where meaningless values are being passed.

In this PR, I will organize the arguments by separating them into `RenderContext` and `GenerationArguments`, allowing us to distinguish between global settings and the state during the render process.