### PR TITLE
Remove redundant tuple in handler type

### DIFF
--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -552,13 +552,13 @@ public final class SwiftType {
             }
         }
 
-         if returnType.isSelf {
-             displayableReturnType = encloser.typeName
+        if returnType.isSelf {
+            displayableReturnType = encloser.typeName
             returnTypeCast = " as! " + String.`Self`
         }
 
-        let isSimpleTuple = displayableReturnType.hasPrefix("(") && displayableReturnType.hasSuffix(")") &&
-            displayableReturnType.components(separatedBy: CharacterSet(charactersIn: "()")).filter({!$0.isEmpty}).count <= 1
+        let isSimpleTuple = !displayableReturnType.isEmpty
+        && displayableReturnType.components(separatedBy: CharacterSet(charactersIn: "()")).filter({!$0.isEmpty}).count <= 1
 
         if !isSimpleTuple {
             displayableReturnType = "(\(displayableReturnType))"

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -181,6 +181,12 @@ public final class SwiftType {
         if isUnknown {
             return false
         }
+
+        var typeName = typeName
+        if typeName.hasPrefix(.any.withSpace) {
+            typeName.removeFirst(String.any.withSpace.count)
+        }
+
         for scalar in typeName.unicodeScalars {
             if scalar == " " {
                 return false

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -472,46 +472,6 @@ public final class SwiftType {
         return nil
     }
 
-
-
-    // Process substrings containing angled or square brackets by replacing a comma delimiter
-    // with another delimiter (e.g. ;) to make it easier to parse tuples
-    // @param arg The type string to be parsed
-    // @param left The opening bracket character
-    // @param right The closing bracket character
-    // @returns The processed string with a new delimiter
-    func parseBrackets(_ arg: String, type: BracketType) -> String {
-        var left = ""
-        var right = ""
-        switch type {
-        case .angle:
-            left = "<"
-            right = ">"
-        case .square:
-            left = "["
-            right = "]"
-        }
-
-        var mutableArg = arg
-        var nextRange: Range<String.Index>? = nil
-        while let leftRange = mutableArg.range(of: left, options: .caseInsensitive, range: nextRange, locale: nil),
-            let rightRange = mutableArg.range(of: right, options: .caseInsensitive, range: nextRange, locale: nil) {
-                let bound = leftRange.lowerBound..<rightRange.lowerBound
-                let sub = mutableArg[bound]
-                let newsub = sub.replacingOccurrences(of: ",", with: ";")
-                mutableArg = mutableArg.replacingOccurrences(of: sub, with: newsub)
-
-                if let nextIdx = mutableArg.index(rightRange.upperBound, offsetBy: 1, limitedBy: mutableArg.endIndex) {
-                    nextRange = nextIdx..<mutableArg.endIndex
-                } else {
-                    break
-                }
-        }
-
-        return mutableArg
-    }
-
-
     static func toClosureType(
         params: [SwiftType],
         typeParams: [String],
@@ -532,7 +492,7 @@ public final class SwiftType {
         var returnAsStr = ""
         var asSuffix = "!"
         var returnTypeCast = ""
-        if !typeParams.filter({ returnComps.contains($0)}).isEmpty {
+        if typeParams.contains(where: { returnComps.contains($0)}) {
             returnAsStr = returnType.typeName
             if returnType.isOptional {
                 displayableReturnType = .anyType + "?"
@@ -557,10 +517,7 @@ public final class SwiftType {
             returnTypeCast = " as! " + String.`Self`
         }
 
-        let isSimpleTuple = !displayableReturnType.isEmpty
-        && displayableReturnType.components(separatedBy: CharacterSet(charactersIn: "()")).filter({!$0.isEmpty}).count <= 1
-
-        if !isSimpleTuple {
+        if !(SwiftType(displayableReturnType).isSingular || SwiftType(displayableReturnType).isOptional) {
             displayableReturnType = "(\(displayableReturnType))"
         }
 

--- a/Tests/TestActor/FixtureActor.swift
+++ b/Tests/TestActor/FixtureActor.swift
@@ -15,7 +15,7 @@ actor FooMock: Foo {
         self.bar = bar
     }
     private(set) var fooCallCount = 0
-    var fooHandler: ((String) async -> (Result<String, Error>))?
+    var fooHandler: ((String) async -> Result<String, Error>)?
     func foo(arg: String) async -> Result<String, Error> {
         fooCallCount += 1
         if let fooHandler = fooHandler {
@@ -51,7 +51,7 @@ actor FooMock: Foo {
     var bar: Int = 0
 
     private(set) var bazCallCount = 0
-    var bazHandler: ((String) async -> (Int))?
+    var bazHandler: ((String) async -> Int)?
     func baz(arg: String) async -> Int {
         bazCallCount += 1
         if let bazHandler = bazHandler {

--- a/Tests/TestActor/FixtureGlobalActor.swift
+++ b/Tests/TestActor/FixtureGlobalActor.swift
@@ -33,7 +33,7 @@ class RootBuildableMock: RootBuildable {
 
 
     private(set) var buildCallCount = 0
-    var buildHandler: (()  -> (RootController))?
+    var buildHandler: (() -> RootController)?
     func build()  -> RootController {
         buildCallCount += 1
         if let buildHandler = buildHandler {

--- a/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
+++ b/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
@@ -146,7 +146,7 @@ class FooMock: Foo {
 
     private(set) var quxFuncCallCount = 0
     var quxFuncArgValues = [Int]()
-    var quxFuncHandler: ((Int) -> (String))?
+    var quxFuncHandler: ((Int) -> String)?
     func quxFunc(val: Int) -> String {
         quxFuncCallCount += 1
         quxFuncArgValues.append(val)
@@ -298,7 +298,7 @@ class FooMock: Foo {
 
     private(set) var barFuncCallCount = 0
     var barFuncArgValues = [Any]()
-    var barFuncHandler: ((Any) -> (Any))?
+    var barFuncHandler: ((Any) -> Any)?
     func barFunc<T: Sequence, U: Collection>(val: T) -> U {
         barFuncCallCount += 1
         barFuncArgValues.append(val)

--- a/Tests/TestClassMocking/FixtureMockableClass.swift
+++ b/Tests/TestClassMocking/FixtureMockableClass.swift
@@ -135,7 +135,7 @@ public class LowMock: Low {
     }
 
     private(set) var fooCallCount = 0
-    var fooHandler: (() -> (Int))?
+    var fooHandler: (() -> Int)?
     override func foo() -> Int {
         fooCallCount += 1
         if let fooHandler = fooHandler {
@@ -187,7 +187,7 @@ public class LowMock: Low {
     }
 
     private(set) var fooCallCount = 0
-    var fooHandler: (() -> (Int))?
+    var fooHandler: (() -> Int)?
     override func foo() -> Int {
         fooCallCount += 1
         if let fooHandler = fooHandler {

--- a/Tests/TestExistentialAny/FixtureExistentialAny.swift
+++ b/Tests/TestExistentialAny/FixtureExistentialAny.swift
@@ -5,11 +5,15 @@ protocol ExistentialAny {
     var bar: any R<Int> { get }
     var baz: any P & Q { get }
     var qux: (any P) -> any P { get }
+
+    func quux() -> P
+    func corge() -> any R<Int>
+    func grault() -> any P & Q
+    func garply() -> (any P) -> any P
 }
 """
 
-let existentialAnyMock =
-"""
+let existentialAnyMock = """
 class ExistentialAnyMock: ExistentialAny {
     init() { }
     init(foo: P, bar: any R<Int>, baz: any P & Q, qux: @escaping (any P) -> any P) {
@@ -20,28 +24,72 @@ class ExistentialAnyMock: ExistentialAny {
     }
 
 
-    private var _foo: P!
+
+    private var _foo: P! 
     var foo: P {
         get { return _foo }
         set { _foo = newValue }
     }
 
-    private var _bar: (any R<Int>)!
+
+    private var _bar: (any R<Int>)! 
     var bar: any R<Int> {
         get { return _bar }
         set { _bar = newValue }
     }
 
-    private var _baz: (any P & Q)!
+
+    private var _baz: (any P & Q)! 
     var baz: any P & Q {
         get { return _baz }
         set { _baz = newValue }
     }
 
-    private var _qux: ((any P) -> any P)!
+
+    private var _qux: ((any P) -> any P)! 
     var qux: (any P) -> any P {
         get { return _qux }
         set { _qux = newValue }
+    }
+
+    private(set) var quuxCallCount = 0
+    var quuxHandler: (() -> P)?
+    func quux() -> P {
+        quuxCallCount += 1
+        if let quuxHandler = quuxHandler {
+            return quuxHandler()
+        }
+        fatalError("quuxHandler returns can't have a default value thus its handler must be set")
+    }
+
+    private(set) var corgeCallCount = 0
+    var corgeHandler: (() -> any R<Int>)?
+    func corge() -> any R<Int> {
+        corgeCallCount += 1
+        if let corgeHandler = corgeHandler {
+            return corgeHandler()
+        }
+        fatalError("corgeHandler returns can't have a default value thus its handler must be set")
+    }
+
+    private(set) var graultCallCount = 0
+    var graultHandler: (() -> (any P & Q))?
+    func grault() -> any P & Q {
+        graultCallCount += 1
+        if let graultHandler = graultHandler {
+            return graultHandler()
+        }
+        fatalError("graultHandler returns can't have a default value thus its handler must be set")
+    }
+
+    private(set) var garplyCallCount = 0
+    var garplyHandler: (() -> ((any P) -> any P))?
+    func garply() -> (any P) -> any P {
+        garplyCallCount += 1
+        if let garplyHandler = garplyHandler {
+            return garplyHandler()
+        }
+        fatalError("garplyHandler returns can't have a default value thus its handler must be set")
     }
 }
 """

--- a/Tests/TestExistentialAny/FixtureExistentialAny.swift
+++ b/Tests/TestExistentialAny/FixtureExistentialAny.swift
@@ -69,7 +69,7 @@ class UseSomeProtocolMock: UseSomeProtocol {
 
 
     private(set) var fooCallCount = 0
-    var fooHandler: (()  -> (any SomeProtocol))?
+    var fooHandler: (()  -> any SomeProtocol)?
     func foo()  -> any SomeProtocol {
         fooCallCount += 1
         if let fooHandler = fooHandler {

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -79,8 +79,6 @@ public protocol KeyValueSubscripting {
 
 
 let subscriptsMocks = """
-
-
 class SubscriptProtocolMock: SubscriptProtocol {
     init() { }
 
@@ -88,7 +86,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     typealias Value = Any
 
     static private(set) var subscriptCallCount = 0
-    static var subscriptHandler: ((Int) -> (AnyObject?))?
+    static var subscriptHandler: ((Int) -> AnyObject?)?
     static subscript(key: Int) -> AnyObject? {
         get {
         subscriptCallCount += 1
@@ -101,7 +99,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptKeyCallCount = 0
-    var subscriptKeyHandler: ((Int) -> (AnyObject))?
+    var subscriptKeyHandler: ((Int) -> AnyObject)?
     subscript(_ key: Int) -> AnyObject {
         get {
         subscriptKeyCallCount += 1
@@ -114,7 +112,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptKeyIntCallCount = 0
-    var subscriptKeyIntHandler: ((Int) -> (AnyObject?))?
+    var subscriptKeyIntHandler: ((Int) -> AnyObject?)?
     subscript(key: Int) -> AnyObject? {
         get {
         subscriptKeyIntCallCount += 1
@@ -127,7 +125,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptIndexCallCount = 0
-    var subscriptIndexHandler: ((String) -> (CGImage?))?
+    var subscriptIndexHandler: ((String) -> CGImage?)?
     subscript(index: String) -> CGImage? {
         get {
         subscriptIndexCallCount += 1
@@ -140,7 +138,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptMemoizeKeyCallCount = 0
-    var subscriptMemoizeKeyHandler: ((Int) -> (CGRect?))?
+    var subscriptMemoizeKeyHandler: ((Int) -> CGRect?)?
     subscript(memoizeKey: Int) -> CGRect? {
         get {
         subscriptMemoizeKeyCallCount += 1
@@ -153,7 +151,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptPositionCallCount = 0
-    var subscriptPositionHandler: ((Int) -> (Any))?
+    var subscriptPositionHandler: ((Int) -> Any)?
     subscript(position: Int) -> Any {
         get {
         subscriptPositionCallCount += 1
@@ -166,7 +164,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptIndexStringIndexCallCount = 0
-    var subscriptIndexStringIndexHandler: ((String.Index) -> (Double))?
+    var subscriptIndexStringIndexHandler: ((String.Index) -> Double)?
     subscript(index: String.Index) -> Double {
         get {
         subscriptIndexStringIndexCallCount += 1
@@ -179,7 +177,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptSafeCallCount = 0
-    var subscriptSafeHandler: ((String.Index) -> (Double?))?
+    var subscriptSafeHandler: ((String.Index) -> Double?)?
     subscript(safe index: String.Index) -> Double? {
         get {
         subscriptSafeCallCount += 1
@@ -192,7 +190,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptRangeCallCount = 0
-    var subscriptRangeHandler: ((Range<Int>) -> (String))?
+    var subscriptRangeHandler: ((Range<Int>) -> String)?
     subscript(range: Range<Int>) -> String {
         get {
         subscriptRangeCallCount += 1
@@ -218,7 +216,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptDynamicMemberCallCount = 0
-    var subscriptDynamicMemberHandler: ((Any) -> (Any))?
+    var subscriptDynamicMemberHandler: ((Any) -> Any)?
     subscript<T>(dynamicMember keyPath: ReferenceWritableKeyPath<Double, T>) -> T {
         get {
         subscriptDynamicMemberCallCount += 1
@@ -231,7 +229,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptDynamicMemberTCallCount = 0
-    var subscriptDynamicMemberTHandler: ((Any) -> (Any))?
+    var subscriptDynamicMemberTHandler: ((Any) -> Any)?
     subscript<T>(dynamicMember keyPath: ReferenceWritableKeyPath<String, T>) -> T {
         get {
         subscriptDynamicMemberTCallCount += 1
@@ -244,7 +242,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptDynamicMemberTWritableKeyPathTValueCallCount = 0
-    var subscriptDynamicMemberTWritableKeyPathTValueHandler: ((Any) -> (Value))?
+    var subscriptDynamicMemberTWritableKeyPathTValueHandler: ((Any) -> Value)?
     subscript<T>(dynamicMember keyPath: WritableKeyPath<T, Value>) -> Value {
         get {
         subscriptDynamicMemberTWritableKeyPathTValueCallCount += 1
@@ -257,7 +255,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptParameterCallCount = 0
-    var subscriptParameterHandler: ((Any) -> (Any))?
+    var subscriptParameterHandler: ((Any) -> Any)?
     subscript<T: ExpressibleByIntegerLiteral>(_ parameter: T) -> T {
         get {
         subscriptParameterCallCount += 1
@@ -270,7 +268,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptKeyPathCallCount = 0
-    var subscriptKeyPathHandler: ((Any) -> (Any))?
+    var subscriptKeyPathHandler: ((Any) -> Any)?
     subscript<Value>(keyPath: ReferenceWritableKeyPath<T, Value>) -> Array<Value> {
         get {
         subscriptKeyPathCallCount += 1
@@ -283,7 +281,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptKeyPathOnCallCount = 0
-    var subscriptKeyPathOnHandler: ((Any, T) -> (Any))?
+    var subscriptKeyPathOnHandler: ((Any, T) -> Any)?
     subscript<Value>(keyPath: ReferenceWritableKeyPath<T, Value>, on schedulerType: T) -> Array<Value> {
         get {
         subscriptKeyPathOnCallCount += 1
@@ -303,7 +301,7 @@ public class KeyValueSubscriptingMock: KeyValueSubscripting {
     public typealias Value = Any
 
     public private(set) var subscriptCallCount = 0
-    public var subscriptHandler: ((Key) -> (Value?))?
+    public var subscriptHandler: ((Key) -> Value?)?
     public subscript(key: Key) -> Value? {
         get {
         subscriptCallCount += 1
@@ -316,7 +314,7 @@ public class KeyValueSubscriptingMock: KeyValueSubscripting {
     }
 
     public private(set) var subscriptKeyCallCount = 0
-    public var subscriptKeyHandler: ((Key, @autoclosure () -> Value) -> (Value))?
+    public var subscriptKeyHandler: ((Key, @autoclosure () -> Value) -> Value)?
     public subscript(key: Key, default defaultValue: @autoclosure () -> Value) -> Value {
         get {
         subscriptKeyCallCount += 1
@@ -352,7 +350,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
 
     private(set) var barCallCount = 0
-    var barHandler: ((String, Int..., [Double]) -> (Float?))?
+    var barHandler: ((String, Int..., [Double]) -> Float?)?
     func bar(_ arg: String, x: Int..., y: [Double]) -> Float? {
         barCallCount += 1
         if let barHandler = barHandler {
@@ -384,7 +382,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
 
     private(set) var passCallCount = 0
-    var passHandler: ((@autoclosure () -> Int) throws -> (Any))?
+    var passHandler: ((@autoclosure () -> Int) throws -> Any)?
     func pass<T>(handler: @autoclosure () -> Int) throws -> T {
         passCallCount += 1
         if let passHandler = passHandler {
@@ -418,7 +416,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
 
     private(set) var catCallCount = 0
-    var catHandler: ((String, [String: String]?, () throws -> Any) throws -> (Any))?
+    var catHandler: ((String, [String: String]?, () throws -> Any) throws -> Any)?
     func cat<T>(named arg: String, tags: [String: String]?, closure: () throws -> T) rethrows -> T {
         catCallCount += 1
         if let catHandler = catHandler {
@@ -428,7 +426,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 
     private(set) var moreCallCount = 0
-    var moreHandler: ((String, [String: String]?, (Any) throws -> ()) throws -> (Any))?
+    var moreHandler: ((String, [String: String]?, (Any) throws -> ()) throws -> Any)?
     func more<T>(named arg: String, tags: [String: String]?, closure: (T) throws -> ()) rethrows -> T {
         moreCallCount += 1
         if let moreHandler = moreHandler {
@@ -535,7 +533,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
 
     private(set) var returnSelfCallCount = 0
-    var returnSelfHandler: (() -> (NonSimpleFuncsMock))?
+    var returnSelfHandler: (() -> NonSimpleFuncsMock)?
     func returnSelf() -> Self {
         returnSelfCallCount += 1
         if let returnSelfHandler = returnSelfHandler {

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -203,7 +203,7 @@ class SubscriptProtocolMock: SubscriptProtocol {
     }
 
     private(set) var subscriptPathCallCount = 0
-    var subscriptPathHandler: ((String) -> (((Double) -> Float)?))?
+    var subscriptPathHandler: ((String) -> ((Double) -> Float)?)?
     subscript(path: String) -> ((Double) -> Float)? {
         get {
         subscriptPathCallCount += 1
@@ -461,7 +461,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
 
 
     private(set) var maxCallCount = 0
-    var maxHandler: ((Int) -> ((() -> Void)?))?
+    var maxHandler: ((Int) -> (() -> Void)?)?
     func max(for: Int) -> (() -> Void)? {
         maxCallCount += 1
         if let maxHandler = maxHandler {
@@ -471,7 +471,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 
     private(set) var maxDoCallCount = 0
-    var maxDoHandler: ((Int) -> ((() -> Void)?))?
+    var maxDoHandler: ((Int) -> (() -> Void)?)?
     func maxDo(do: Int) -> (() -> Void)? {
         maxDoCallCount += 1
         if let maxDoHandler = maxDoHandler {
@@ -481,7 +481,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 
     private(set) var maxInCallCount = 0
-    var maxInHandler: ((Int) -> ((() -> Void)?))?
+    var maxInHandler: ((Int) -> (() -> Void)?)?
     func maxIn(in: Int) -> (() -> Void)? {
         maxInCallCount += 1
         if let maxInHandler = maxInHandler {
@@ -491,7 +491,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 
     private(set) var maxSwitchCallCount = 0
-    var maxSwitchHandler: ((Int) -> ((() -> Void)?))?
+    var maxSwitchHandler: ((Int) -> (() -> Void)?)?
     func maxSwitch(for switch: Int) -> (() -> Void)? {
         maxSwitchCallCount += 1
         if let maxSwitchHandler = maxSwitchHandler {
@@ -501,7 +501,7 @@ class NonSimpleFuncsMock: NonSimpleFuncs {
     }
 
     private(set) var maxExtensionCallCount = 0
-    var maxExtensionHandler: ((Int) -> ((() -> Void)?))?
+    var maxExtensionHandler: ((Int) -> (() -> Void)?)?
     func maxExtension(extension: Int) -> (() -> Void)? {
         maxExtensionCallCount += 1
         if let maxExtensionHandler = maxExtensionHandler {

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureSimpleFuncs.swift
@@ -18,7 +18,7 @@ public class SimpleFuncMock: SimpleFunc {
 
 
     public private(set) var updateCallCount = 0
-    public var updateHandler: ((Int) -> (String))?
+    public var updateHandler: ((Int) -> String)?
     public func update(arg: Int) -> String {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -40,7 +40,7 @@ public class SimpleFuncMock: SimpleFunc {
 
 
     public var updateCallCount = 0
-    public var updateHandler: ((Int) -> (String))?
+    public var updateHandler: ((Int) -> String)?
     public func update(arg: Int) -> String {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -61,7 +61,7 @@ public class SimpleFuncMock: SimpleFunc {
 
 
     public private(set) var updateCallCount = 0
-    public var updateHandler: ((Int) -> (String))?
+    public var updateHandler: ((Int) -> String)?
     public func update(arg: Int) -> String {
         mockFunc(&updateCallCount)("update", updateHandler?(arg), .val(""))
     }

--- a/Tests/TestFuncs/TestFuncAsync/FixtureFuncAsync.swift
+++ b/Tests/TestFuncs/TestFuncAsync/FixtureFuncAsync.swift
@@ -28,7 +28,7 @@ class FuncAsyncMock: FuncAsync {
 
 
     private(set) var f1CallCount = 0
-    var f1Handler: ((Int) async -> (String))?
+    var f1Handler: ((Int) async -> String)?
     func f1(arg: Int) async -> String {
         f1CallCount += 1
         if let f1Handler = f1Handler {
@@ -48,7 +48,7 @@ class FuncAsyncMock: FuncAsync {
     }
 
     private(set) var g1CallCount = 0
-    var g1Handler: (((Int) async -> ()) async -> (String))?
+    var g1Handler: (((Int) async -> ()) async -> String)?
     func g1(arg: (Int) async -> ()) async -> String {
         g1CallCount += 1
         if let g1Handler = g1Handler {
@@ -68,7 +68,7 @@ class FuncAsyncMock: FuncAsync {
     }
 
     private(set) var updateCallCount = 0
-    var updateHandler: ((Any, Any) async -> (Any))?
+    var updateHandler: ((Any, Any) async -> Any)?
     func update<T, U>(arg1: T, arg2: @escaping (U) async -> ()) async -> ((T) -> (U)) {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -108,7 +108,7 @@ class FuncAsyncThrowsMock: FuncAsyncThrows {
 
 
     private(set) var f1CallCount = 0
-    var f1Handler: ((Int) async throws -> (String))?
+    var f1Handler: ((Int) async throws -> String)?
     func f1(arg: Int) async throws -> String {
         f1CallCount += 1
         if let f1Handler = f1Handler {
@@ -128,7 +128,7 @@ class FuncAsyncThrowsMock: FuncAsyncThrows {
     }
 
     private(set) var g1CallCount = 0
-    var g1Handler: (((Int) async throws -> ()) async throws -> (String))?
+    var g1Handler: (((Int) async throws -> ()) async throws -> String)?
     func g1(arg: (Int) async throws -> ()) async throws -> String {
         g1CallCount += 1
         if let g1Handler = g1Handler {
@@ -148,7 +148,7 @@ class FuncAsyncThrowsMock: FuncAsyncThrows {
     }
 
     private(set) var updateCallCount = 0
-    var updateHandler: ((Any, Any) async throws -> (Any))?
+    var updateHandler: ((Any, Any) async throws -> Any)?
     func update<T, U>(arg1: T, arg2: @escaping (U) async throws -> ()) async throws -> ((T) -> (U)) {
         updateCallCount += 1
         if let updateHandler = updateHandler {

--- a/Tests/TestFuncs/TestFuncThrow/FixtureFuncThrow.swift
+++ b/Tests/TestFuncs/TestFuncThrow/FixtureFuncThrow.swift
@@ -32,7 +32,7 @@ class FuncThrowMock: FuncThrow {
 
 
     private(set) var f1CallCount = 0
-    var f1Handler: ((Int) throws -> (String))?
+    var f1Handler: ((Int) throws -> String)?
     func f1(arg: Int) throws -> String {
         f1CallCount += 1
         if let f1Handler = f1Handler {
@@ -62,7 +62,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var f4CallCount = 0
-    var f4Handler: ((Int) throws(SomeError) -> (String))?
+    var f4Handler: ((Int) throws(SomeError) -> String)?
     func f4(arg: Int) throws(SomeError) -> String {
         f4CallCount += 1
         if let f4Handler = f4Handler {
@@ -92,7 +92,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var g1CallCount = 0
-    var g1Handler: (((Int) throws -> ()) throws -> (String))?
+    var g1Handler: (((Int) throws -> ()) throws -> String)?
     func g1(arg: (Int) throws -> ()) throws -> String {
         g1CallCount += 1
         if let g1Handler = g1Handler {
@@ -112,7 +112,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var hCallCount = 0
-    var hHandler: (((Int) throws -> ()) throws -> (String))?
+    var hHandler: (((Int) throws -> ()) throws -> String)?
     func h(arg: (Int) throws -> ()) rethrows -> String {
         hCallCount += 1
         if let hHandler = hHandler {
@@ -122,7 +122,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var h2CallCount = 0
-    var h2Handler: (((Int) throws(SomeError) -> ()) throws -> (String))?
+    var h2Handler: (((Int) throws(SomeError) -> ()) throws -> String)?
     func h2(arg: (Int) throws(SomeError) -> ()) rethrows -> String {
         h2CallCount += 1
         if let h2Handler = h2Handler {
@@ -132,7 +132,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var updateCallCount = 0
-    var updateHandler: ((Any, Any) throws -> (Any))?
+    var updateHandler: ((Any, Any) throws -> Any)?
     func update<T, U>(arg1: T, arg2: @escaping (U) throws -> ()) throws -> ((T) -> (U)) {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -142,7 +142,7 @@ class FuncThrowMock: FuncThrow {
     }
 
     private(set) var updateArg1CallCount = 0
-    var updateArg1Handler: ((Any, () throws -> Any) throws -> (Any))?
+    var updateArg1Handler: ((Any, () throws -> Any) throws -> Any)?
     func update<T>(arg1: T, arg2: () throws -> T) rethrows -> T {
         updateArg1CallCount += 1
         if let updateArg1Handler = updateArg1Handler {

--- a/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
+++ b/Tests/TestFuncs/TestGenericFuncs/FixtureGenericFunc.swift
@@ -16,7 +16,7 @@ public class GenericProtocolMock: GenericProtocol {
 
 
     public private(set) var nonOptionalCallCount = 0
-    public var nonOptionalHandler: (() -> (Any))?
+    public var nonOptionalHandler: (() -> Any)?
     public func nonOptional<T>() -> T {
         nonOptionalCallCount += 1
         if let nonOptionalHandler = nonOptionalHandler {
@@ -26,7 +26,7 @@ public class GenericProtocolMock: GenericProtocol {
     }
 
     public private(set) var optionalCallCount = 0
-    public var optionalHandler: (() -> (Any?))?
+    public var optionalHandler: (() -> Any?)?
     public func optional<T>() -> T? {
         optionalCallCount += 1
         if let optionalHandler = optionalHandler {
@@ -70,7 +70,7 @@ class GenericFuncMock: GenericFunc {
 
 
     private(set) var containsGenericCallCount = 0
-    var containsGenericHandler: ((Any, Any) -> (Any))?
+    var containsGenericHandler: ((Any, Any) -> Any)?
     func containsGeneric<T: StringProtocol, U: ExpressibleByIntegerLiteral>(arg1: T, arg2: @escaping (U) -> ()) -> ((T) -> (U)) {
         containsGenericCallCount += 1
         if let containsGenericHandler = containsGenericHandler {
@@ -90,7 +90,7 @@ class GenericFuncMock: GenericFunc {
     }
 
     private(set) var pushCallCount = 0
-    var pushHandler: ((Request, StatusCode.Type?) -> (Any))?
+    var pushHandler: ((Request, StatusCode.Type?) -> Any)?
     func push<T: Body>(_ request: Request, statusErrorCodeType: StatusCode.Type?) -> Observable<T> {
         pushCallCount += 1
         if let pushHandler = pushHandler {
@@ -100,7 +100,7 @@ class GenericFuncMock: GenericFunc {
     }
 
     private(set) var fetchCallCount = 0
-    var fetchHandler: ((Request, StatusCode.Type?) -> (Any))?
+    var fetchHandler: ((Request, StatusCode.Type?) -> Any)?
     func fetch<T: Body>(_ request: Request, statusErrorCodeType: StatusCode.Type?) -> Observable<T> {
         fetchCallCount += 1
         if let fetchHandler = fetchHandler {
@@ -110,7 +110,7 @@ class GenericFuncMock: GenericFunc {
     }
 
     private(set) var tellCallCount = 0
-    var tellHandler: ((ResponseType, Any) -> (Disposable))?
+    var tellHandler: ((ResponseType, Any) -> Disposable)?
     func tell<BodyType: Body>(_ type: ResponseType, with handler: @escaping (BodyType) -> ()) -> Disposable {
         tellCallCount += 1
         if let tellHandler = tellHandler {
@@ -120,7 +120,7 @@ class GenericFuncMock: GenericFunc {
     }
 
     private(set) var tellTypeCallCount = 0
-    var tellTypeHandler: ((ResponseType, Any) -> (Disposable))?
+    var tellTypeHandler: ((ResponseType, Any) -> Disposable)?
     func tell<BodyType: AnotherBody>(_ type: ResponseType, with handler: @escaping (BodyType) -> ()) -> Disposable {
         tellTypeCallCount += 1
         if let tellTypeHandler = tellTypeHandler {
@@ -218,7 +218,7 @@ class NetworkingMock: Networking {
 
 
     private(set) var requestCallCount = 0
-    var requestHandler: ((Any) -> (Any))?
+    var requestHandler: ((Any) -> Any)?
     func request<T>(_ target: T) -> T.ResultType where T: APITarget & Parsable {
         requestCallCount += 1
         if let requestHandler = requestHandler {

--- a/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
+++ b/Tests/TestFuncs/TestOpaqueTypeFuncs/FixtureOpaqueTypeFunc.swift
@@ -16,7 +16,7 @@ public class OpaqueTypeProtocolMock: OpaqueTypeProtocol {
 
 
     public private(set) var nonOptionalCallCount = 0
-    public var nonOptionalHandler: ((Any) -> (Int))?
+    public var nonOptionalHandler: ((Any) -> Int)?
     public func nonOptional(_ type: some Error) -> Int {
         nonOptionalCallCount += 1
         if let nonOptionalHandler = nonOptionalHandler {
@@ -57,7 +57,7 @@ public class OpaqueTypeWithMultiTypeProtocolMock: OpaqueTypeWithMultiTypeProtoco
 
 
     public private(set) var nonOptionalCallCount = 0
-    public var nonOptionalHandler: ((Any) -> (Int))?
+    public var nonOptionalHandler: ((Any) -> Int)?
     public func nonOptional(_ type: some Error) -> Int {
         nonOptionalCallCount += 1
         if let nonOptionalHandler = nonOptionalHandler {

--- a/Tests/TestInit/FixtureInit.swift
+++ b/Tests/TestInit/FixtureInit.swift
@@ -237,7 +237,7 @@ public class ForcastUpdatingMock: ForcastUpdating {
 
 
     public private(set) var enabledCallCount = 0
-    public var enabledHandler: (() -> (Bool))?
+    public var enabledHandler: (() -> Bool)?
     public func enabled() -> Bool {
         enabledCallCount += 1
         if let enabledHandler = enabledHandler {
@@ -247,7 +247,7 @@ public class ForcastUpdatingMock: ForcastUpdating {
     }
 
     public private(set) var forcastLoaderCallCount = 0
-    public var forcastLoaderHandler: (() -> (ForcastLoading?))?
+    public var forcastLoaderHandler: (() -> ForcastLoading?)?
     public func forcastLoader() -> ForcastLoading? {
         forcastLoaderCallCount += 1
         if let forcastLoaderHandler = forcastLoaderHandler {

--- a/Tests/TestNamespaces/FixtureModuleOverrides.swift
+++ b/Tests/TestNamespaces/FixtureModuleOverrides.swift
@@ -20,7 +20,7 @@ class TaskRoutingMock: Foo.TaskRouting {
 
     var bar: String = ""
     private(set) var bazCallCount = 0
-    var bazHandler: (() -> (Double))?
+    var bazHandler: (() -> Double)?
     func baz() -> Double {
         bazCallCount += 1
         if let bazHandler = bazHandler {

--- a/Tests/TestNamespaces/FixtureNestedProtocol.swift
+++ b/Tests/TestNamespaces/FixtureNestedProtocol.swift
@@ -78,7 +78,7 @@ class OKMock: OK {
     typealias T = Any
 
     private(set) var requirementCallCount = 0
-    var requirementHandler: (()  -> (T))?
+    var requirementHandler: (()  -> T)?
     func requirement()  -> T {
         requirementCallCount += 1
         if let requirementHandler = requirementHandler {

--- a/Tests/TestOverloads/FixtureDuplicates1.swift
+++ b/Tests/TestOverloads/FixtureDuplicates1.swift
@@ -67,7 +67,7 @@ class FooMock: Foo {
     }
 
     private(set) var updateIntCallCount = 0
-    var updateIntHandler: (() -> (Int))?
+    var updateIntHandler: (() -> Int)?
     func update() -> Int {
         updateIntCallCount += 1
         if let updateIntHandler = updateIntHandler {

--- a/Tests/TestOverloads/FixtureDuplicates2.swift
+++ b/Tests/TestOverloads/FixtureDuplicates2.swift
@@ -37,7 +37,7 @@ class FooMock: Foo {
     }
 
     private(set) var updateArgCallCount = 0
-    var updateArgHandler: ((Int, Float) -> (Int))?
+    var updateArgHandler: ((Int, Float) -> Int)?
     func update(arg: Int, some: Float) -> Int {
         updateArgCallCount += 1
         if let updateArgHandler = updateArgHandler {
@@ -47,7 +47,7 @@ class FooMock: Foo {
     }
 
     private(set) var updateArgSomeCallCount = 0
-    var updateArgSomeHandler: ((Int, Float) -> (Observable<Int>))?
+    var updateArgSomeHandler: ((Int, Float) -> Observable<Int>)?
     func update(arg: Int, some: Float) -> Observable<Int> {
         updateArgSomeCallCount += 1
         if let updateArgSomeHandler = updateArgSomeHandler {
@@ -67,7 +67,7 @@ class FooMock: Foo {
     }
 
     private(set) var updateArgSomeIntFloatCallCount = 0
-    var updateArgSomeIntFloatHandler: ((Int, Float) -> (Array<String, Float>))?
+    var updateArgSomeIntFloatHandler: ((Int, Float) -> Array<String, Float>)?
     func update(arg: Int, some: Float) -> Array<String, Float> {
         updateArgSomeIntFloatCallCount += 1
         if let updateArgSomeIntFloatHandler = updateArgSomeIntFloatHandler {

--- a/Tests/TestOverloads/FixtureDuplicates3.swift
+++ b/Tests/TestOverloads/FixtureDuplicates3.swift
@@ -24,7 +24,7 @@ class FooMock: Foo {
 
 
     private(set) var collectionViewCallCount = 0
-    var collectionViewHandler: ((UICollectionView, Int) -> (String?))?
+    var collectionViewHandler: ((UICollectionView, Int) -> String?)?
     func collectionView(_ collectionView: UICollectionView, reuseIdentifierForItemAt index: Int) -> String? {
         collectionViewCallCount += 1
         if let collectionViewHandler = collectionViewHandler {
@@ -44,7 +44,7 @@ class FooMock: Foo {
     }
 
     private(set) var collectionViewSizeForItemAtCallCount = 0
-    var collectionViewSizeForItemAtHandler: ((UICollectionView, Int) -> (CGSize))?
+    var collectionViewSizeForItemAtHandler: ((UICollectionView, Int) -> CGSize)?
     func collectionView(_ collectionView: UICollectionView, sizeForItemAt index: Int) -> CGSize {
         collectionViewSizeForItemAtCallCount += 1
         if let collectionViewSizeForItemAtHandler = collectionViewSizeForItemAtHandler {
@@ -74,7 +74,7 @@ class FooMock: Foo {
     }
 
     private(set) var loadImageCallCount = 0
-    var loadImageHandler: ((URL) -> (Observable<UIImage>))?
+    var loadImageHandler: ((URL) -> Observable<UIImage>)?
     func loadImage(atURL url: URL) -> Observable<UIImage> {
         loadImageCallCount += 1
         if let loadImageHandler = loadImageHandler {
@@ -84,7 +84,7 @@ class FooMock: Foo {
     }
 
     private(set) var loadImageAtURLCallCount = 0
-    var loadImageAtURLHandler: ((URL, UIImage) -> (Observable<UIImage>))?
+    var loadImageAtURLHandler: ((URL, UIImage) -> Observable<UIImage>)?
     func loadImage(atURL url: URL, placeholder: UIImage) -> Observable<UIImage> {
         loadImageAtURLCallCount += 1
         if let loadImageAtURLHandler = loadImageAtURLHandler {
@@ -94,7 +94,7 @@ class FooMock: Foo {
     }
 
     private(set) var loadImageAtURLRetryIntervalCallCount = 0
-    var loadImageAtURLRetryIntervalHandler: ((URL, RxTimeInterval, Int) -> (Observable<UIImage>))?
+    var loadImageAtURLRetryIntervalHandler: ((URL, RxTimeInterval, Int) -> Observable<UIImage>)?
     func loadImage(atURL url: URL, retryInterval: RxTimeInterval, maxRetries: Int) -> Observable<UIImage> {
         loadImageAtURLRetryIntervalCallCount += 1
         if let loadImageAtURLRetryIntervalHandler = loadImageAtURLRetryIntervalHandler {

--- a/Tests/TestOverloads/FixtureFuncOverload2.swift
+++ b/Tests/TestOverloads/FixtureFuncOverload2.swift
@@ -17,7 +17,7 @@ public class BarMock: Bar {
     }
     
     public private(set) var tellCallCount = 0
-    public var tellHandler: (([String: String], ClientProtocol) -> (Observable<EncryptedData>))?
+    public var tellHandler: (([String: String], ClientProtocol) -> Observable<EncryptedData>)?
     public func tell(data: [String: String], for client: ClientProtocol) -> Observable<EncryptedData> {
         tellCallCount += 1
         if let tellHandler = tellHandler {
@@ -27,7 +27,7 @@ public class BarMock: Bar {
     }
     
     public private(set) var tellKeyCallCount = 0
-    public var tellKeyHandler: ((Double) -> (Int))?
+    public var tellKeyHandler: ((Double) -> Int)?
     public func tell(key: Double) -> Int {
         tellKeyCallCount += 1
         if let tellKeyHandler = tellKeyHandler {
@@ -40,16 +40,13 @@ public class BarMock: Bar {
 
 """
 
-let overloadMock2 =
-
-"""
-
+let overloadMock2 = """
 public class FooMock: Foo {
     public init() { }
 
 
     public private(set) var tellStatusCallCount = 0
-    public var tellStatusHandler: ((Int, String) -> (Double))?
+    public var tellStatusHandler: ((Int, String) -> Double)?
     public func tell(status: Int, msg: String) -> Double {
         tellStatusCallCount += 1
         if let tellStatusHandler = tellStatusHandler {
@@ -59,7 +56,7 @@ public class FooMock: Foo {
     }
     
     public private(set) var tellCallCount = 0
-    public var tellHandler: (([String: String], ClientProtocol) -> (Observable<EncryptedData>))?
+    public var tellHandler: (([String: String], ClientProtocol) -> Observable<EncryptedData>)?
     public func tell(data: [String: String], for client: ClientProtocol) -> Observable<EncryptedData> {
         tellCallCount += 1
         if let tellHandler = tellHandler {
@@ -69,7 +66,7 @@ public class FooMock: Foo {
     }
     
     public private(set) var tellKeyCallCount = 0
-    public var tellKeyHandler: ((Double) -> (Int))?
+    public var tellKeyHandler: ((Double) -> Int)?
     public func tell(key: Double) -> Int {
         tellKeyCallCount += 1
         if let tellKeyHandler = tellKeyHandler {
@@ -78,5 +75,4 @@ public class FooMock: Foo {
         return 0
     }
 }
-
 """

--- a/Tests/TestOverloads/FixtureInheritance.swift
+++ b/Tests/TestOverloads/FixtureInheritance.swift
@@ -46,7 +46,7 @@ public class SimpleChildMock: SimpleChild {
     public private(set) var numberSetCallCount = 0
     public var number: Int = 0 { didSet { numberSetCallCount += 1 } }
     public private(set) var barCallCount = 0
-    public var barHandler: ((Double) -> (Float?))?
+    public var barHandler: ((Double) -> Float?)?
     public func bar(arg: Double) -> Float? {
         barCallCount += 1
         if let barHandler = barHandler {
@@ -68,7 +68,7 @@ public class SimpleParentMock: SimpleParent {
     public private(set) var numberSetCallCount = 0
     public var number: Int = 0 { didSet { numberSetCallCount += 1 } }
     public private(set) var barCallCount = 0
-    public var barHandler: ((Double) -> (Float?))?
+    public var barHandler: ((Double) -> Float?)?
     public func bar(arg: Double) -> Float? {
         barCallCount += 1
         if let barHandler = barHandler {
@@ -128,7 +128,7 @@ class TestProtocolMock: TestProtocol {
     var someInt: Int = 0 { didSet { someIntSetCallCount += 1 } }
 
     private(set) var doSomethingElseCallCount = 0
-    var doSomethingElseHandler: (() -> (Bool))?
+    var doSomethingElseHandler: (() -> Bool)?
     func doSomethingElse() -> Bool {
         doSomethingElseCallCount += 1
         if let doSomethingElseHandler = doSomethingElseHandler {

--- a/Tests/TestRx/FixtureRxVars.swift
+++ b/Tests/TestRx/FixtureRxVars.swift
@@ -72,7 +72,7 @@ class TaskRoutingMock: TaskRouting {
         set { if let val = newValue as? BehaviorSubject<Bool> { attachedRouterSubject = val } else { _attachedRouter = newValue } }
     }
     private(set) var routeToFooCallCount = 0
-    var routeToFooHandler: (() -> (Observable<()>))?
+    var routeToFooHandler: (() -> Observable<()>)?
     func routeToFoo() -> Observable<()> {
         routeToFooCallCount += 1
         if let routeToFooHandler = routeToFooHandler {

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -16,7 +16,7 @@ public class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
 
 
     public private(set) var updateCallCount = 0
-    public var updateHandler: ((Int) -> (String))?
+    public var updateHandler: ((Int) -> String)?
     public func update(arg: Int) -> String {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -44,7 +44,7 @@ public class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Send
 
 
     private(set) var updateCallCount = 0
-    var updateHandler: ((Int) -> (String))?
+    var updateHandler: ((Int) -> String)?
     override func update(arg: Int) -> String {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -67,15 +67,12 @@ public protocol ConfirmedSendableProtocol: SendableSendable {
 """
 
 let confirmedSendableProtocolMock = """
-
-
-
 public class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
     public init() { }
 
 
     public private(set) var updateCallCount = 0
-    public var updateHandler: ((Int) -> (String))?
+    public var updateHandler: ((Int) -> String)?
     public func update(arg: Int) -> String {
         updateCallCount += 1
         if let updateHandler = updateHandler {
@@ -84,5 +81,4 @@ public class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecke
         return ""
     }
 }
-
 """

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -59,7 +59,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateObservableItemTypeCallCount = 0
-    var updateObservableItemTypeHandler: (() -> (Observable<(ItemType, ())>))?
+    var updateObservableItemTypeHandler: (() -> Observable<(ItemType, ())>)?
     func update() -> Observable<(ItemType, ())> {
         updateObservableItemTypeCallCount += 1
         if let updateObservableItemTypeHandler = updateObservableItemTypeHandler {
@@ -69,7 +69,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateObservableItemTypeOptionalCallCount = 0
-    var updateObservableItemTypeOptionalHandler: (() -> (Observable<(ItemType, ())>?))?
+    var updateObservableItemTypeOptionalHandler: (() -> Observable<(ItemType, ())>?)?
     func update() -> Observable<(ItemType, ())>? {
         updateObservableItemTypeOptionalCallCount += 1
         if let updateObservableItemTypeOptionalHandler = updateObservableItemTypeOptionalHandler {
@@ -219,7 +219,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateDoubleIntFloatStringIntDoubleIntCallCount = 0
-    var updateDoubleIntFloatStringIntDoubleIntHandler: (() -> ((Double, Int, (Float, (String, Int, Double), Int), Float, (Int, String), Array<String>)))?
+    var updateDoubleIntFloatStringIntDoubleIntHandler: (() -> (Double, Int, (Float, (String, Int, Double), Int), Float, (Int, String), Array<String>))?
     func update() -> (Double, Int, (Float, (String, Int, Double), Int), Float, (Int, String), Array<String>) {
         updateDoubleIntFloatStringIntDoubleIntCallCount += 1
         if let updateDoubleIntFloatStringIntDoubleIntHandler = updateDoubleIntFloatStringIntDoubleIntHandler {
@@ -259,7 +259,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateDictionaryAArrayTUBIntCallCount = 0
-    var updateDictionaryAArrayTUBIntHandler: (() -> ((Dictionary<A, (Array<(T, U)>, B)>, Int)))?
+    var updateDictionaryAArrayTUBIntHandler: (() -> (Dictionary<A, (Array<(T, U)>, B)>, Int))?
     func update() -> (Dictionary<A, (Array<(T, U)>, B)>, Int) {
         updateDictionaryAArrayTUBIntCallCount += 1
         if let updateDictionaryAArrayTUBIntHandler = updateDictionaryAArrayTUBIntHandler {
@@ -268,6 +268,4 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return (Dictionary<A, (Array<(T, U)>, B)>(), 0)
     }
 }
-
-
 """

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -34,15 +34,13 @@ func update() -> (Dictionary<A, (Array<(T, U)>, B)>, Int)
 
 
 let tuplesBracketsMock = """
-
-
 class NonSimpleTypesMock: NonSimpleTypes {
     init() { }
 
 
     private(set) var variadicFuncCallCount = 0
     var variadicFuncHandler: ((Int, String) -> ())?
-    func variadicFunc(_ arg: Int, for key: String)  {
+    func variadicFunc(_ arg: Int, for key: String) {
         variadicFuncCallCount += 1
         if let variadicFuncHandler = variadicFuncHandler {
             variadicFuncHandler(arg, key)
@@ -81,7 +79,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateObservableSomeKeySomeTypeCallCount = 0
-    var updateObservableSomeKeySomeTypeHandler: (() -> (Observable<[SomeKey: SomeType]>))?
+    var updateObservableSomeKeySomeTypeHandler: (() -> Observable<[SomeKey: SomeType]>)?
     func update() -> Observable<[SomeKey: SomeType]> {
         updateObservableSomeKeySomeTypeCallCount += 1
         if let updateObservableSomeKeySomeTypeHandler = updateObservableSomeKeySomeTypeHandler {
@@ -91,7 +89,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateStringIntCallCount = 0
-    var updateStringIntHandler: (() -> ([String: Int]))?
+    var updateStringIntHandler: (() -> [String: Int])?
     func update() -> [String: Int] {
         updateStringIntCallCount += 1
         if let updateStringIntHandler = updateStringIntHandler {
@@ -101,7 +99,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateDictionaryStringIntCallCount = 0
-    var updateDictionaryStringIntHandler: (() -> (Dictionary<String, Int>))?
+    var updateDictionaryStringIntHandler: (() -> Dictionary<String, Int>)?
     func update() -> Dictionary<String, Int> {
         updateDictionaryStringIntCallCount += 1
         if let updateDictionaryStringIntHandler = updateDictionaryStringIntHandler {
@@ -111,7 +109,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateObservableDoubleFloatCallCount = 0
-    var updateObservableDoubleFloatHandler: (() -> (Observable<Double, Float>))?
+    var updateObservableDoubleFloatHandler: (() -> Observable<Double, Float>)?
     func update() -> Observable<Double, Float> {
         updateObservableDoubleFloatCallCount += 1
         if let updateObservableDoubleFloatHandler = updateObservableDoubleFloatHandler {
@@ -121,7 +119,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateStringCallCount = 0
-    var updateStringHandler: (() -> ([String]))?
+    var updateStringHandler: (() -> [String])?
     func update() -> [String] {
         updateStringCallCount += 1
         if let updateStringHandler = updateStringHandler {
@@ -131,7 +129,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateStringArrayIntCallCount = 0
-    var updateStringArrayIntHandler: (() -> ([String: Array<Int>]))?
+    var updateStringArrayIntHandler: (() -> [String: Array<Int>])?
     func update() -> [String: Array<Int>] {
         updateStringArrayIntCallCount += 1
         if let updateStringArrayIntHandler = updateStringArrayIntHandler {
@@ -141,7 +139,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateStringDictionaryIntDoubleCallCount = 0
-    var updateStringDictionaryIntDoubleHandler: (() -> ([String: Dictionary<Int, Double>]))?
+    var updateStringDictionaryIntDoubleHandler: (() -> [String: Dictionary<Int, Double>])?
     func update() -> [String: Dictionary<Int, Double>] {
         updateStringDictionaryIntDoubleCallCount += 1
         if let updateStringDictionaryIntDoubleHandler = updateStringDictionaryIntDoubleHandler {
@@ -161,7 +159,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateArrayStringIntCallCount = 0
-    var updateArrayStringIntHandler: (() -> (Array<[String: Int]>))?
+    var updateArrayStringIntHandler: (() -> Array<[String: Int]>)?
     func update() -> Array<[String: Int]> {
         updateArrayStringIntCallCount += 1
         if let updateArrayStringIntHandler = updateArrayStringIntHandler {
@@ -171,7 +169,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateArrayDictionaryStringIntCallCount = 0
-    var updateArrayDictionaryStringIntHandler: (() -> (Array<Dictionary<String, Int>>))?
+    var updateArrayDictionaryStringIntHandler: (() -> Array<Dictionary<String, Int>>)?
     func update() -> Array<Dictionary<String, Int>> {
         updateArrayDictionaryStringIntCallCount += 1
         if let updateArrayDictionaryStringIntHandler = updateArrayDictionaryStringIntHandler {
@@ -191,7 +189,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateArrayStringCallCount = 0
-    var updateArrayStringHandler: (() -> (Array<String>))?
+    var updateArrayStringHandler: (() -> Array<String>)?
     func update() -> Array<String> {
         updateArrayStringCallCount += 1
         if let updateArrayStringHandler = updateArrayStringHandler {
@@ -231,7 +229,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateArgCallCount = 0
-    var updateArgHandler: ((Int, Float) -> (Dictionary<String, Float>))?
+    var updateArgHandler: ((Int, Float) -> Dictionary<String, Float>)?
     func update(arg: Int, some: Float) -> Dictionary<String, Float> {
         updateArgCallCount += 1
         if let updateArgHandler = updateArgHandler {
@@ -241,7 +239,7 @@ class NonSimpleTypesMock: NonSimpleTypes {
     }
 
     private(set) var updateArgSomeCallCount = 0
-    var updateArgSomeHandler: ((Int, Float) -> (Observable<Int>))?
+    var updateArgSomeHandler: ((Int, Float) -> Observable<Int>)?
     func update(arg: Int, some: Float) -> Observable<Int> {
         updateArgSomeCallCount += 1
         if let updateArgSomeHandler = updateArgSomeHandler {


### PR DESCRIPTION
Simple refactoring. This PR does not include functional changes.

Remove redundant tuple in handler type. 
ex: before `(Int) -> (String)`, after `(Int) -> String`