### PR TITLE
Concurrency safe handler

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -1,11 +1,24 @@
-import Foundation
+//
+//  Copyright (c) 2018. Uber Technologies
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//  http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
 
 final class ArgumentsHistoryModel: Model {
     let name: String
-    let type: SwiftType
+    let capturedValueType: SwiftType
     let offset: Int64 = .max
-    let capturableParamNames: [String]
-    let capturableParamTypes: [SwiftType]
+    let capturableParams: [(String, SwiftType)]
     let isHistoryAnnotated: Bool
 
     var modelType: ModelType {
@@ -22,11 +35,10 @@ final class ArgumentsHistoryModel: Model {
         self.name = name + .argsHistorySuffix
         self.isHistoryAnnotated = isHistoryAnnotated
 
-        self.capturableParamNames = capturables.map(\.name.safeName)
-        self.capturableParamTypes = capturables.map(\.type)
+        self.capturableParams = capturables.map { ($0.name.safeName, $0.type) }
         
         let genericTypeNameList = genericTypeParams.map(\.name)
-        self.type = SwiftType.toArgumentsHistoryType(with: capturableParamTypes, typeParams: genericTypeNameList)
+        self.capturedValueType = SwiftType.toArgumentsCaptureType(with: capturableParams.map(\.1), typeParams: genericTypeNameList)
     }
     
     func enable(force: Bool) -> Bool {
@@ -44,11 +56,11 @@ final class ArgumentsHistoryModel: Model {
             return nil
         }
         
-        switch capturableParamNames.count {
+        switch capturableParams.count {
         case 1:
-            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append(\(capturableParamNames[0]))"
+            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append(\(capturableParams[0].0))"
         case 2...:
-            let paramNamesStr = capturableParamNames.joined(separator: ", ")
+            let paramNamesStr = capturableParams.map(\.0).joined(separator: ", ")
             return "\(overloadingResolvedName)\(String.argsHistorySuffix).append((\(paramNamesStr)))"
         default:
             fatalError("paramNames must not be empty.")

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -53,7 +53,7 @@ final class ClosureModel: Model {
 
     func render(
         context: RenderContext,
-        arguments: GenerationArguments = .default
+        arguments: GenerationArguments
     ) -> String? {
         guard let overloadingResolvedName = context.overloadingResolvedName,
               let enclosingType = context.enclosingType else {

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -40,14 +40,15 @@ final class ClosureModel: Model {
         self.funcReturnType = returnType
     }
 
-    func type(enclosingType: SwiftType) -> SwiftType {
+    func type(enclosingType: SwiftType, requiresSendable: Bool) -> SwiftType {
         return SwiftType.toClosureType(
             params: params.map(\.1),
             typeParams: genericTypeNames,
             isAsync: isAsync,
             throwing: throwing,
             returnType: funcReturnType,
-            encloser: enclosingType
+            encloser: enclosingType,
+            requiresSendable: requiresSendable
         )
     }
 
@@ -59,7 +60,7 @@ final class ClosureModel: Model {
               let enclosingType = context.enclosingType else {
             return nil
         }
-        return applyClosureTemplate(type: type(enclosingType: enclosingType),
+        return applyClosureTemplate(type: type(enclosingType: enclosingType, requiresSendable: context.requiresSendable),
                                     name: overloadingResolvedName + .handlerSuffix,
                                     params: params,
                                     returnDefaultType: funcReturnType)

--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -22,8 +22,7 @@ final class ClosureModel: Model {
 
     let funcReturnType: SwiftType
     let genericTypeNames: [String]
-    let paramNames: [String]
-    let paramTypes: [SwiftType]
+    let params: [(String, SwiftType)]
     let isAsync: Bool
     let throwing: ThrowingKind
 
@@ -31,20 +30,19 @@ final class ClosureModel: Model {
         return .closure
     }
 
-    init(genericTypeParams: [ParamModel], paramNames: [String], paramTypes: [SwiftType], isAsync: Bool, throwing: ThrowingKind, returnType: SwiftType) {
+    init(genericTypeParams: [ParamModel], params: [(String, SwiftType)], isAsync: Bool, throwing: ThrowingKind, returnType: SwiftType) {
         // In the mock's call handler, rethrows is unavailable.
         let throwing = throwing.coerceRethrowsToThrows
         self.isAsync = isAsync
         self.throwing = throwing
         self.genericTypeNames = genericTypeParams.map(\.name)
-        self.paramNames = paramNames
-        self.paramTypes = paramTypes
+        self.params = params
         self.funcReturnType = returnType
     }
 
     func type(enclosingType: SwiftType) -> SwiftType {
         return SwiftType.toClosureType(
-            params: paramTypes,
+            params: params.map(\.1),
             typeParams: genericTypeNames,
             isAsync: isAsync,
             throwing: throwing,
@@ -63,8 +61,7 @@ final class ClosureModel: Model {
         }
         return applyClosureTemplate(type: type(enclosingType: enclosingType),
                                     name: overloadingResolvedName + .handlerSuffix,
-                                    paramVals: paramNames,
-                                    paramTypes: paramTypes,
+                                    params: params,
                                     returnDefaultType: funcReturnType)
     }
 }

--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -142,8 +142,7 @@ final class MethodModel: Model {
         }
 
         return ClosureModel(genericTypeParams: genericTypeParams,
-                            paramNames: params.map(\.name),
-                            paramTypes: params.map(\.type),
+                            params: params.map { ($0.name, $0.type) },
                             isAsync: isAsync,
                             throwing: throwing,
                             returnType: returnType)

--- a/Sources/MockoloFramework/Models/Model.swift
+++ b/Sources/MockoloFramework/Models/Model.swift
@@ -37,6 +37,7 @@ struct RenderContext {
     var overloadingResolvedName: String?
     var enclosingType: SwiftType?
     var annotatedTypeKind: NominalTypeDeclKind?
+    var requiresSendable: Bool = false
 }
 
 /// Represents a model for an entity such as var, func, class, etc.

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -28,6 +28,7 @@ final class NominalModel: Model {
     let declaredInits: [MethodModel]
     let metadata: AnnotationMetadata?
     let declKind: NominalTypeDeclKind
+    let requiresSendable: Bool
 
     var modelType: ModelType {
         return .nominal
@@ -43,8 +44,9 @@ final class NominalModel: Model {
          metadata: AnnotationMetadata?,
          initParamCandidates: [VariableModel],
          declaredInits: [MethodModel],
-         entities: [(String, Model)]) {
-        self.identifier = identifier 
+         entities: [(String, Model)],
+         requiresSendable: Bool) {
+        self.identifier = identifier
         self.name = metadata?.nameOverride ?? (identifier + "Mock")
         self.type = SwiftType(self.name)
         self.namespaces = namespaces
@@ -57,6 +59,7 @@ final class NominalModel: Model {
         self.offset = offset
         self.attribute = Set(attributes.filter {$0.contains(String.available)}).joined(separator: " ")
         self.accessLevel = acl
+        self.requiresSendable = requiresSendable
     }
     
     func render(

--- a/Sources/MockoloFramework/Models/NominalModel.swift
+++ b/Sources/MockoloFramework/Models/NominalModel.swift
@@ -23,7 +23,6 @@ final class NominalModel: Model {
     let accessLevel: String
     let identifier: String
     let declKindOfMockAnnotatedBaseType: NominalTypeDeclKind
-    let inheritedTypes: [String]
     let entities: [(String, Model)]
     let initParamCandidates: [VariableModel]
     let declaredInits: [MethodModel]
@@ -39,7 +38,6 @@ final class NominalModel: Model {
          acl: String,
          declKindOfMockAnnotatedBaseType: NominalTypeDeclKind,
          declKind: NominalTypeDeclKind,
-         inheritedTypes: [String],
          attributes: [String],
          offset: Int64,
          metadata: AnnotationMetadata?,
@@ -52,7 +50,6 @@ final class NominalModel: Model {
         self.namespaces = namespaces
         self.declKindOfMockAnnotatedBaseType = declKindOfMockAnnotatedBaseType
         self.declKind = declKind
-        self.inheritedTypes = inheritedTypes
         self.entities = entities
         self.declaredInits = declaredInits
         self.initParamCandidates = initParamCandidates
@@ -71,7 +68,6 @@ final class NominalModel: Model {
             identifier: self.identifier,
             accessLevel: accessLevel,
             attribute: attribute,
-            inheritedTypes: inheritedTypes,
             metadata: metadata,
             arguments: arguments,
             initParamCandidates: initParamCandidates,

--- a/Sources/MockoloFramework/Models/ParamModel.swift
+++ b/Sources/MockoloFramework/Models/ParamModel.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-import Foundation
-
 final class ParamModel: Model {
     internal init(label: String, name: String, type: SwiftType, isGeneric: Bool, inInit: Bool, needsVarDecl: Bool, offset: Int64, length: Int64) {
         self.label = label
@@ -84,9 +82,23 @@ final class ParamModel: Model {
     }
     
     func render(
-        context: RenderContext = .init(),
-        arguments: GenerationArguments = .default
+        context: RenderContext,
+        arguments: GenerationArguments
     ) -> String? {
         return applyParamTemplate(name: name, label: label, type: type, inInit: inInit)
+    }
+}
+
+extension [ParamModel] {
+    func render(
+        context: RenderContext,
+        arguments: GenerationArguments
+    ) -> String {
+        return self.compactMap {
+            $0.render(
+                context: context,
+                arguments: arguments
+            )
+        }.joined(separator: ", ")
     }
 }

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -23,7 +23,6 @@ struct ResolvedEntity {
     var uniqueModels: [(String, Model)]
     var attributes: [String]
     var inheritedTypes: [String]
-    var inheritsActorProtocol: Bool
 
     var declaredInits: [MethodModel] {
         return uniqueModels.compactMap { (_, model) in
@@ -37,6 +36,10 @@ struct ResolvedEntity {
         return sortedInitVars(
             in: uniqueModels.compactMap{ $0.1 as? VariableModel }
         )
+    }
+
+    var inheritsActorProtocol: Bool {
+        return inheritedTypes.contains(.actorProtocol)
     }
 
     /// Returns models that can be used as parameters to an initializer
@@ -62,7 +65,6 @@ struct ResolvedEntity {
                             acl: entity.entityNode.accessLevel,
                             declKindOfMockAnnotatedBaseType: entity.entityNode.declKind,
                             declKind: inheritsActorProtocol ? .actor : .class,
-                            inheritedTypes: inheritedTypes,
                             attributes: attributes,
                             offset: entity.entityNode.offset,
                             metadata: entity.metadata,

--- a/Sources/MockoloFramework/Models/ParsedEntity.swift
+++ b/Sources/MockoloFramework/Models/ParsedEntity.swift
@@ -59,6 +59,10 @@ struct ResolvedEntity {
         return result
     }
 
+    var requiresSendable: Bool {
+        return inheritedTypes.contains(.sendable) || inheritedTypes.contains(.error)
+    }
+
     func model() -> Model {
         return NominalModel(identifier: key,
                             namespaces: entity.entityNode.namespaces,
@@ -70,7 +74,8 @@ struct ResolvedEntity {
                             metadata: entity.metadata,
                             initParamCandidates: initParamCandidates,
                             declaredInits: declaredInits,
-                            entities: uniqueModels)
+                            entities: uniqueModels,
+                            requiresSendable: requiresSendable)
     }
 }
 

--- a/Sources/MockoloFramework/Models/TypeAliasModel.swift
+++ b/Sources/MockoloFramework/Models/TypeAliasModel.swift
@@ -58,7 +58,7 @@ final class TypeAliasModel: Model {
 
     func render(
         context: RenderContext,
-        arguments: GenerationArguments = .default
+        arguments: GenerationArguments
     ) -> String? {
         let addAcl = context.annotatedTypeKind == .protocol && !processed
         if processed || useDescription, let modelDescription = modelDescription?.trimmingCharacters(in: .whitespacesAndNewlines) {

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -127,6 +127,7 @@ final class VariableModel: Model {
                                      allowSetCallCount: arguments.allowSetCallCount,
                                      shouldOverride: shouldOverride,
                                      accessLevel: accessLevel,
-                                     context: context)
+                                     context: context,
+                                     arguments: arguments)
     }
 }

--- a/Sources/MockoloFramework/Operations/Generator.swift
+++ b/Sources/MockoloFramework/Operations/Generator.swift
@@ -157,17 +157,25 @@ public func generate(sourceDirs: [String],
     signpost_begin(name: "Write results")
     log("Write the mock results and import lines to", outputFilePath, level: .info)
 
+    let needsConcurrencyHelpers = resolvedEntities.contains { $0.requiresSendable }
+
     let imports = handleImports(pathToImportsMap: pathToImportsMap,
-                                customImports: customImports,
+                                customImports: customImports + (needsConcurrencyHelpers ? ["Foundation"] : []),
                                 excludeImports: excludeImports,
                                 testableImports: testableImports,
                                 relevantPaths: relevantPaths)
 
+    var helpers = [String]()
+    if needsConcurrencyHelpers {
+        helpers.append(applyConcurrencyHelpersTemplate())
+    }
+
     let result = try write(candidates: candidates,
-                       header: header,
-                       macro: macro,
-                       imports: imports,
-                       to: outputFilePath)
+                           header: header,
+                           macro: macro,
+                           imports: imports,
+                           helpers: helpers,
+                           to: outputFilePath)
     signpost_end(name: "Write results")
     let t5 = CFAbsoluteTimeGetCurrent()
     log("Took", t5-t4, level: .verbose)

--- a/Sources/MockoloFramework/Operations/OutputWriter.swift
+++ b/Sources/MockoloFramework/Operations/OutputWriter.swift
@@ -21,6 +21,7 @@ func write(candidates: [(String, Int64)],
            header: String?,
            macro: String?,
            imports: String,
+           helpers: [String],
            to outputFilePath: String) throws -> String {
 
     let entities = candidates
@@ -35,11 +36,18 @@ func write(candidates: [(String, Int64)],
     let headerStr = (header ?? "") + .headerDoc
     var macroStart = ""
     var macroEnd = ""
-    if let mcr = macro, !mcr.isEmpty {
-        macroStart = .poundIf + mcr
+    if let macro, !macro.isEmpty {
+        macroStart = .poundIf + macro
         macroEnd = .poundEndIf
     }
-    let ret = [headerStr, macroStart, imports, entities.joined(separator: "\n"), macroEnd].joined(separator: "\n\n")
+    let ret = [
+        headerStr,
+        macroStart,
+        imports,
+        entities.joined(separator: "\n"),
+        helpers.joined(separator: "\n\n"),
+        macroEnd,
+    ].joined(separator: "\n\n")
     let currentFileContents = try? String(contentsOfFile: outputFilePath, encoding: .utf8)
     guard currentFileContents != ret else {
         log("Not writing the file as content is unchanged", level: .info)

--- a/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
+++ b/Sources/MockoloFramework/Operations/UniqueModelGenerator.swift
@@ -68,18 +68,12 @@ private func generateUniqueModels(key: String,
     let uniqueModels = [mockedUniqueEntities, unmockedUniqueEntities].flatMap {$0}
         .sorted(path: \.value.offset, fallback: \.key)
 
-    var mockInheritedTypes = [String]()
-    if inheritedTypes.contains(.sendable) {
-        mockInheritedTypes.append(.uncheckedSendable)
-    }
-
     let resolvedEntity = ResolvedEntity(
         key: key,
         entity: entity,
         uniqueModels: uniqueModels,
         attributes: attributes,
-        inheritedTypes: mockInheritedTypes,
-        inheritsActorProtocol: inheritedTypes.contains(.actorProtocol)
+        inheritedTypes: inheritedTypes.sorted()
     )
 
     return ResolvedEntityContainer(entity: resolvedEntity, paths: paths)

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -19,28 +19,21 @@ import Foundation
 extension ClosureModel {
     func applyClosureTemplate(type: SwiftType,
                               name: String,
-                              paramVals: [String]?,
-                              paramTypes: [SwiftType]?,
+                              params: [(String, SwiftType)],
                               returnDefaultType: SwiftType) -> String {
-        
-        var handlerParamValsStr = ""
-        if let paramVals = paramVals, let paramTypes = paramTypes {
-            let zipped = zip(paramVals, paramTypes).map { (arg) -> String in
-                let (argName, argType) = arg
-                if argType.isAutoclosure {
-                    return argName.safeName + "()"
-                }
-                if argType.isInOut {
-                    return "&" + argName.safeName
-                }
-                if argType.hasClosure && argType.isOptional,
-                    let renderedClosure = renderOptionalGenericClosure(argType: argType, argName: argName) {
-                    return renderedClosure
-                }
-                return argName.safeName
+        let handlerParamValsStr = params.map { (argName, argType) -> String in
+            if argType.isAutoclosure {
+                return argName.safeName + "()"
             }
-            handlerParamValsStr = zipped.joined(separator: ", ")
-        }
+            if argType.isInOut {
+                return "&" + argName.safeName
+            }
+            if argType.hasClosure && argType.isOptional,
+               let renderedClosure = renderOptionalGenericClosure(argType: argType, argName: argName) {
+                return renderedClosure
+            }
+            return argName.safeName
+        }.joined(separator: ", ")
         let handlerReturnDefault = renderReturnDefaultStatement(name: name, type: returnDefaultType)
         
         let prefix = [

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -41,17 +41,14 @@ extension ClosureModel {
             isAsync ? String.await + " " : nil,
         ].compactMap { $0 }.joined()
         
-        let returnStr = returnDefaultType.typeName.isEmpty ? "" : "return "
-        let callExpr = "\(returnStr)\(prefix)\(name)(\(handlerParamValsStr))\(type.cast ?? "")"
-        
-        let template = """
+        let returnStr = returnDefaultType.isVoid ? "" : "return "
+
+        return """
         \(2.tab)if let \(name) = \(name) {
-        \(3.tab)\(callExpr)
+        \(3.tab)\(returnStr)\(prefix)\(name)(\(handlerParamValsStr))\(type.cast ?? "")
         \(2.tab)}
         \(2.tab)\(handlerReturnDefault)
         """
-        
-        return template
     }
     
     

--- a/Sources/MockoloFramework/Templates/ConcurrencyHelpersTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ConcurrencyHelpersTemplate.swift
@@ -1,0 +1,45 @@
+func applyConcurrencyHelpersTemplate() -> String {
+    return #"""
+fileprivate func warnIfNotSendable<each T>(function: String = #function, _: repeat each T) {
+    print("At \(function), the captured arguments are not Sendable, it is not concurrency-safe.")
+}
+
+fileprivate func warnIfNotSendable<each T: Sendable>(function: String = #function, _: repeat each T) {
+}
+
+/// Will be replaced to `Synchronization.Mutex` in future.
+fileprivate final class MockoloMutex<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+    init(_ initialValue: Value) {
+        self.value = initialValue
+    }
+#if compiler(>=6.0)
+    borrowing func withLock<Result, E: Error>(_ body: (inout sending Value) throws(E) -> Result) throws(E) -> sending Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+#else
+    func withLock<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+#endif
+}
+
+fileprivate struct MockoloUnsafeTransfer<Value>: @unchecked Sendable {
+    var value: Value
+    init<each T>(_ value: repeat each T) where Value == (repeat each T) {
+        self.value = (repeat each value)
+    }
+}
+
+fileprivate struct MockoloHandlerState<Arg, Handler> {
+    var argValues: [MockoloUnsafeTransfer<Arg>] = []
+    var handler: Handler? = nil
+    var callCount: Int = 0
+}
+"""#
+}

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -82,7 +82,7 @@ extension MethodModel {
                     argsHistoryCaptureCall = ""
                 }
 
-                let handlerReturn = handler.render(context: context) ?? ""
+                let handlerReturn = handler.render(context: context, arguments: arguments) ?? ""
 
                 body = """
                 \(2.tab)\(callCountVarName) += 1
@@ -106,9 +106,9 @@ extension MethodModel {
             }
 
             let keyword = model.isSubscript ? "" : "func "
-            let genericTypeDeclsStr = model.genericTypeParams.compactMap {$0.render()}.joined(separator: ", ")
+            let genericTypeDeclsStr = model.genericTypeParams.render(context: context, arguments: arguments)
             let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
-            let paramDeclsStr = model.params.compactMap{$0.render()}.joined(separator: ", ")
+            let paramDeclsStr = model.params.render(context: context, arguments: arguments)
             let suffixStr = applyFunctionSuffixTemplate(
                 isAsync: model.isAsync,
                 throwing: model.throwing

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -53,7 +53,7 @@ extension MethodModel {
             let body: String
             if arguments.useTemplateFunc
                 && !model.throwing.hasError
-                && (handler.type(enclosingType: enclosingType).cast?.isEmpty ?? false) {
+                && (handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).cast?.isEmpty ?? false) {
                 let handlerParamValsStr = model.params.map { (arg) -> String in
                     if arg.type.typeName.hasPrefix(String.autoclosure) {
                         return arg.name.safeName + "()"
@@ -180,7 +180,7 @@ extension MethodModel {
         var stateVarDecl: String? {
             guard context.requiresSendable else { return nil }
 
-            let handlerType = handler.type(enclosingType: enclosingType).typeName
+            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).typeName
             let argumentsTupleType: String
             if let argsHistory = model.argsHistory, argsHistory.enable(force: arguments.enableFuncArgsHistory) {
                 argumentsTupleType = argsHistory.capturedValueType.typeName
@@ -230,7 +230,7 @@ extension MethodModel {
         }
 
         var handlerVarDecl: String {
-            let handlerType = handler.type(enclosingType: enclosingType).typeName // ?? "Any"
+            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).typeName // ?? "Any"
             let handlerVarType = "(\(handlerType))?"
             if !context.requiresSendable {
                 return "\(1.tab)\(declModifiers)var \(handlerVarName): \(handlerVarType)"

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -161,14 +161,14 @@ extension MethodModel {
         var stateVarDecl: String? {
             guard context.requiresSendable else { return nil }
 
-            let handlerVarType = handler.type(enclosingType: enclosingType).typeName
+            let handlerType = handler.type(enclosingType: enclosingType).typeName
             let argumentsTupleType: String
             if let argsHistory = model.argsHistory, argsHistory.enable(force: arguments.enableFuncArgsHistory) {
                 argumentsTupleType = argsHistory.capturedValueType.typeName
             } else {
                 argumentsTupleType = .neverType
             }
-            return "\(1.tab)private let \(stateVarName) = MockoloMutex(MockoloHandlerState<\(argumentsTupleType), \(handlerVarType)>())"
+            return "\(1.tab)private let \(stateVarName) = MockoloMutex(MockoloHandlerState<\(argumentsTupleType), \(handlerType)>())"
         }
 
         var callCountVarDecl: String {
@@ -211,7 +211,8 @@ extension MethodModel {
         }
 
         var handlerVarDecl: String {
-            let handlerVarType = handler.type(enclosingType: enclosingType).typeName // ?? "Any"
+            let handlerType = handler.type(enclosingType: enclosingType).typeName // ?? "Any"
+            let handlerVarType = "(\(handlerType))?"
             if !context.requiresSendable {
                 return "\(1.tab)\(declModifiers)var \(handlerVarName): \(handlerVarType)"
             } else {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -72,7 +72,19 @@ extension NominalModel {
             moduleDot = moduleName + "."
         }
         
-        let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits, acl: acl, declKindOfMockAnnotatedBaseType: declKindOfMockAnnotatedBaseType, overrides: metadata?.varTypes)
+        let extraInits = extraInitsIfNeeded(
+            initParamCandidates: initParamCandidates,
+            declaredInits: declaredInits,
+            acl: acl,
+            declKindOfMockAnnotatedBaseType: declKindOfMockAnnotatedBaseType,
+            overrides: metadata?.varTypes,
+            context: .init(
+                enclosingType: type,
+                annotatedTypeKind: declKindOfMockAnnotatedBaseType,
+                requiresSendable: requiresSendable
+            ),
+            arguments: arguments
+        )
 
         var body = ""
         if !typealiasTemplate.isEmpty {
@@ -109,7 +121,9 @@ extension NominalModel {
         declaredInits: [MethodModel],
         acl: String,
         declKindOfMockAnnotatedBaseType: NominalTypeDeclKind,
-        overrides: [String: String]?
+        overrides: [String: String]?,
+        context: RenderContext,
+        arguments: GenerationArguments
     ) -> String {
         
         let declaredInitParamsPerInit = declaredInits.map { $0.params }
@@ -194,9 +208,9 @@ extension NominalModel {
             if case let .initKind(required, override) = m.kind, !m.processed {
                 let modifier = required ? "\(String.required) " : (override ? "\(String.override) " : "")
                 let mAcl = m.accessLevel.isEmpty ? "" : "\(m.accessLevel) "
-                let genericTypeDeclsStr = m.genericTypeParams.compactMap {$0.render()}.joined(separator: ", ")
+                let genericTypeDeclsStr = m.genericTypeParams.render(context: context, arguments: arguments)
                 let genericTypesStr = genericTypeDeclsStr.isEmpty ? "" : "<\(genericTypeDeclsStr)>"
-                let paramDeclsStr = m.params.compactMap{$0.render()}.joined(separator: ", ")
+                let paramDeclsStr = m.params.render(context: context, arguments: arguments)
                 let suffixStr = applyFunctionSuffixTemplate(
                     isAsync: m.isAsync,
                     throwing: m.throwing

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -97,7 +97,7 @@ extension NominalModel {
             body += "\(renderedEntities)"
         }
 
-        let finalStr = arguments.mockFinal ? "\(String.final) " : ""
+        let finalStr = arguments.mockFinal || requiresSendable ? String.final.withSpace : ""
         let template = """
         \(attribute)
         \(acl)\(finalStr)\(declKind.rawValue) \(name): \(moduleDot)\(identifier) {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -96,11 +96,15 @@ extension NominalModel {
         if !renderedEntities.isEmpty {
             body += "\(renderedEntities)"
         }
+        var uncheckedSendableStr = ""
+        if requiresSendable {
+            uncheckedSendableStr = ", @unchecked Sendable"
+        }
 
         let finalStr = arguments.mockFinal || requiresSendable ? String.final.withSpace : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)\(declKind.rawValue) \(name): \(moduleDot)\(identifier) {
+        \(acl)\(finalStr)\(declKind.rawValue) \(name): \(moduleDot)\(identifier)\(uncheckedSendableStr) {
         \(body)
         }
         """

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -21,7 +21,6 @@ extension NominalModel {
                               identifier: String,
                               accessLevel: String,
                               attribute: String,
-                              inheritedTypes: [String],
                               metadata: AnnotationMetadata?,
                               arguments: GenerationArguments,
                               initParamCandidates: [VariableModel],
@@ -74,9 +73,6 @@ extension NominalModel {
         
         let extraInits = extraInitsIfNeeded(initParamCandidates: initParamCandidates, declaredInits: declaredInits, acl: acl, declKindOfMockAnnotatedBaseType: declKindOfMockAnnotatedBaseType, overrides: metadata?.varTypes)
 
-        var inheritedTypes = inheritedTypes
-        inheritedTypes.insert("\(moduleDot)\(identifier)", at: 0)
-
         var body = ""
         if !typealiasTemplate.isEmpty {
             body += "\(typealiasTemplate)\n"
@@ -91,7 +87,7 @@ extension NominalModel {
         let finalStr = arguments.mockFinal ? "\(String.final) " : ""
         let template = """
         \(attribute)
-        \(acl)\(finalStr)\(declKind.rawValue) \(name): \(inheritedTypes.joined(separator: ", ")) {
+        \(acl)\(finalStr)\(declKind.rawValue) \(name): \(moduleDot)\(identifier) {
         \(body)
         }
         """

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -47,7 +47,8 @@ extension NominalModel {
                     context: .init(
                         overloadingResolvedName: uniqueId,
                         enclosingType: type,
-                        annotatedTypeKind: declKindOfMockAnnotatedBaseType
+                        annotatedTypeKind: declKindOfMockAnnotatedBaseType,
+                        requiresSendable: requiresSendable
                     ),
                     arguments: arguments
                 ) {

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -25,7 +25,8 @@ extension VariableModel {
                                allowSetCallCount: Bool,
                                shouldOverride: Bool,
                                accessLevel: String,
-                               context: RenderContext) -> String {
+                               context: RenderContext,
+                               arguments: GenerationArguments) -> String {
         let underlyingSetCallCount = "\(name)\(String.setCallCountSuffix)"
         let underlyingVarDefaultVal = type.defaultVal()
         var underlyingType = type.typeName
@@ -115,7 +116,7 @@ extension VariableModel {
                 overloadingResolvedName: name, // var cannot overload. this is ok
                 enclosingType: context.enclosingType,
                 annotatedTypeKind: context.annotatedTypeKind
-            )) ?? "")
+            ), arguments: arguments) ?? "")
                 .addingIndent(1)
 
             return """

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -17,7 +17,6 @@
 import Foundation
 
 extension VariableModel {
-
     func applyVariableTemplate(name: String,
                                type: SwiftType,
                                encloser: String,
@@ -27,7 +26,6 @@ extension VariableModel {
                                shouldOverride: Bool,
                                accessLevel: String,
                                context: RenderContext) -> String {
-
         let underlyingSetCallCount = "\(name)\(String.setCallCountSuffix)"
         let underlyingVarDefaultVal = type.defaultVal()
         var underlyingType = type.typeName
@@ -358,14 +356,7 @@ extension VariableModel {
 
 extension VariableModel.GetterEffects {
     fileprivate func applyTemplate() -> String {
-        var clauses: [String] = []
-        if isAsync {
-            clauses.append(.async)
-        }
-        if let throwSyntax = throwing.applyThrowingTemplate() {
-            clauses.append(throwSyntax)
-        }
-        return clauses.map { "\($0) " }.joined()
+        return applyFunctionSuffixTemplate(isAsync: isAsync, throwing: throwing)
     }
 
     fileprivate var callerMarkers: String {

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -107,8 +107,7 @@ extension VariableModel {
         case .computed(let effects):
             let body = (ClosureModel(
                 genericTypeParams: [],
-                paramNames: [],
-                paramTypes: [],
+                params: [],
                 isAsync: effects.isAsync,
                 throwing: effects.throwing,
                 returnType: type

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -99,7 +99,7 @@ extension String {
     static let autoclosure = "@autoclosure"
     static let name = "name"
     static let sendable = "Sendable"
-    static let uncheckedSendable = "@unchecked Sendable"
+    static let error = "Error"
     static let mainActor = "MainActor"
     static public let mockAnnotation = "@mockable"
     static public let mockObservable = "@MockObservable"

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -94,6 +94,7 @@ extension String {
     static let underlyingVarPrefix = "_"
     static let setCallCountSuffix = "SetCallCount"
     static let callCountSuffix = "CallCount"
+    static let stateSuffix = "State"
     static let initializerLeftParen = "init("
     static let `escaping` = "@escaping"
     static let autoclosure = "@autoclosure"

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -536,7 +536,7 @@ public final class SwiftType {
         return SwiftType(typeStr, cast: returnTypeCast)
     }
     
-    static func toArgumentsHistoryType(with params: [SwiftType], typeParams: [String]) -> SwiftType {
+    static func toArgumentsCaptureType(with params: [SwiftType], typeParams: [String]) -> SwiftType {
         // Expected only history capturable types.
         let displayableParamTypes = params.compactMap { (subtype: SwiftType) -> String? in
             var processedType = subtype.processTypeParams(with: typeParams)
@@ -554,9 +554,9 @@ public final class SwiftType {
         let displayableParamStr = displayableParamTypes.joined(separator: ", ")
 
         if displayableParamTypes.count >= 2 {
-            return SwiftType("[(\(displayableParamStr))]")
+            return SwiftType("(\(displayableParamStr))")
         } else {
-            return SwiftType("[\(displayableParamStr)]")
+            return SwiftType(displayableParamStr)
         }
     }
 

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -488,7 +488,8 @@ public final class SwiftType {
         isAsync: Bool,
         throwing: ThrowingKind,
         returnType: SwiftType,
-        encloser: SwiftType
+        encloser: SwiftType,
+        requiresSendable: Bool
     ) -> SwiftType {
         let displayableParamTypes = params.map { (subtype: SwiftType) -> String in
             return subtype.processTypeParams(with: typeParams)
@@ -536,7 +537,8 @@ public final class SwiftType {
             throwing: throwing
         )
 
-        let typeStr = "(\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType)"
+        let sendableStr = requiresSendable ? "@Sendable " : ""
+        let typeStr = "\(sendableStr)(\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType)"
         return SwiftType(typeStr, cast: returnTypeCast)
     }
     

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -532,7 +532,7 @@ public final class SwiftType {
             throwing: throwing
         )
 
-        let typeStr = "((\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType))?"
+        let typeStr = "(\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType)"
         return SwiftType(typeStr, cast: returnTypeCast)
     }
     

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -200,6 +200,10 @@ public final class SwiftType {
         return true
     }
 
+    var isVoid: Bool {
+        return typeName.isEmpty || typeName == "()" || typeName == "Void"
+    }
+
     var hasValidBrackets: Bool {
         let arg = typeName
         if let _ = arg.rangeOfCharacter(from: CharacterSet(arrayLiteral: "<", "["), options: [], range: nil) {

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -9,7 +9,7 @@ public protocol SendableProtocol: Sendable {
 """
 
 let sendableProtocolMock = #"""
-public final class SendableProtocolMock: SendableProtocol {
+public final class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
     public init() { }
 
 
@@ -72,7 +72,7 @@ public class UncheckedSendableClass: @unchecked Sendable {
 """
 
 let uncheckedSendableClassMock = #"""
-public final class UncheckedSendableClassMock: UncheckedSendableClass {
+public final class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {
     public init() { }
 
 
@@ -108,7 +108,7 @@ public protocol ConfirmedSendableProtocol: SendableSendable {
 """
 
 let confirmedSendableProtocolMock = #"""
-public final class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol {
+public final class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
     public init() { }
 
 
@@ -142,7 +142,7 @@ public protocol SendableProtocol: Sendable {
 let generatedConcurrencyHelpersMock = #"""
 import Foundation
 
-public final class SendableProtocolMock: SendableProtocol {
+public final class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
     public init() { }
 }
 

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -4,29 +4,65 @@ let sendableProtocol = """
 /// \(String.mockAnnotation)
 public protocol SendableProtocol: Sendable {
     func update(arg: Int) -> String
+    func update(arg0: some Sendable, arg1: AnyObject) async throws
 }
 """
 
-let sendableProtocolMock = """
-
-
-
-public class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
+let sendableProtocolMock = #"""
+public final class SendableProtocolMock: SendableProtocol {
     public init() { }
 
 
-    public private(set) var updateCallCount = 0
-    public var updateHandler: ((Int) -> String)?
+    private let updateState = MockoloMutex(MockoloHandlerState<Int, (Int) -> String>())
+    public var updateCallCount: Int {
+        return updateState.withLock(\.callCount)
+    }
+    public var updateArgValues: [Int] {
+        return updateState.withLock(\.argValues).map(\.value)
+    }
+    public var updateHandler: ((Int) -> String)? {
+        get { updateState.withLock(\.handler) }
+        set { updateState.withLock { $0.handler = newValue } }
+    }
     public func update(arg: Int) -> String {
-        updateCallCount += 1
+        warnIfNotSendable(arg)
+        let updateHandler = updateState.withLock { state in
+            state.callCount += 1
+            state.argValues.append(.init(arg))
+            return state.handler
+        }
         if let updateHandler = updateHandler {
             return updateHandler(arg)
         }
         return ""
     }
-}
 
-"""
+    private let updateArg0State = MockoloMutex(MockoloHandlerState<(Any, AnyObject), (Any, AnyObject) async throws -> ()>())
+    public var updateArg0CallCount: Int {
+        return updateArg0State.withLock(\.callCount)
+    }
+    public var updateArg0ArgValues: [(Any, AnyObject)] {
+        return updateArg0State.withLock(\.argValues).map(\.value)
+    }
+    public var updateArg0Handler: ((Any, AnyObject) async throws -> ())? {
+        get { updateArg0State.withLock(\.handler) }
+        set { updateArg0State.withLock { $0.handler = newValue } }
+    }
+    public func update(arg0: some Sendable, arg1: AnyObject) async throws {
+        warnIfNotSendable(arg0, arg1)
+        let updateArg0Handler = updateArg0State.withLock { state in
+            state.callCount += 1
+            state.argValues.append(.init(arg0, arg1))
+            return state.handler
+        }
+        if let updateArg0Handler = updateArg0Handler {
+            try await updateArg0Handler(arg0, arg1)
+        }
+        
+    }
+}
+"""#
+
 
 let uncheckedSendableClass = """
 /// \(String.mockAnnotation)

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -132,3 +132,59 @@ public final class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol {
     }
 }
 """#
+
+let generatedConcurrencyHelpers = """
+/// \(String.mockAnnotation)
+public protocol SendableProtocol: Sendable {
+}
+"""
+
+let generatedConcurrencyHelpersMock = #"""
+import Foundation
+
+public final class SendableProtocolMock: SendableProtocol {
+    public init() { }
+}
+
+fileprivate func warnIfNotSendable<each T>(function: String = #function, _: repeat each T) {
+    print("At \(function), the captured arguments are not Sendable, it is not concurrency-safe.")
+}
+
+fileprivate func warnIfNotSendable<each T: Sendable>(function: String = #function, _: repeat each T) {
+}
+
+/// Will be replaced to `Synchronization.Mutex` in future.
+fileprivate final class MockoloMutex<Value>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var value: Value
+    init(_ initialValue: Value) {
+        self.value = initialValue
+    }
+#if compiler(>=6.0)
+    borrowing func withLock<Result, E: Error>(_ body: (inout sending Value) throws(E) -> Result) throws(E) -> sending Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+#else
+    func withLock<Result>(_ body: (inout Value) throws -> Result) rethrows -> Result {
+        lock.lock()
+        defer { lock.unlock() }
+        return try body(&value)
+    }
+#endif
+}
+
+fileprivate struct MockoloUnsafeTransfer<Value>: @unchecked Sendable {
+    var value: Value
+    init<each T>(_ value: repeat each T) where Value == (repeat each T) {
+        self.value = (repeat each value)
+    }
+}
+
+fileprivate struct MockoloHandlerState<Arg, Handler> {
+    var argValues: [MockoloUnsafeTransfer<Arg>] = []
+    var handler: Handler? = nil
+    var callCount: Int = 0
+}
+"""#

--- a/Tests/TestSendable/SendableTests.swift
+++ b/Tests/TestSendable/SendableTests.swift
@@ -1,7 +1,8 @@
 class SendableTests: MockoloTestCase {
     func testSendableProtocol() {
         verify(srcContent: sendableProtocol,
-               dstContent: sendableProtocolMock)
+               dstContent: sendableProtocolMock,
+               enableFuncArgsHistory: true)
     }
 
     func testUncheckedSendableClass() {

--- a/Tests/TestSendable/SendableTests.swift
+++ b/Tests/TestSendable/SendableTests.swift
@@ -15,4 +15,9 @@ class SendableTests: MockoloTestCase {
         verify(srcContent: confirmedSendableProtocol,
                dstContent: confirmedSendableProtocolMock)
     }
+
+    func testGenerateConcurrencyHelpers() {
+        verify(srcContent: generatedConcurrencyHelpers,
+               dstContent: generatedConcurrencyHelpersMock)
+    }
 }


### PR DESCRIPTION
Issue: https://github.com/uber/mockolo/issues/249

When the mock protocol requires `Sendable`,  correctly implement the mock functions as `Sendable`. To provide a concurrency-safe implementation, we also add some helper functions and types.

This PR does not address stored properties or computed properties (Do it later).

As shown below, various function `Handler`s are required to be `Sendable`.

```swift
/// @mockable
protocol APIClient: Sendable {
    func fetchData(_ id: AnyObject) async -> Int
}
```

```swift
final class APIClientMock: APIClient {
    init() { }

    private let fetchDataState = MockoloMutex(MockoloHandlerState<AnyObject, @Sendable (AnyObject) async -> Int>())
    var fetchDataCallCount: Int {
        return fetchDataState.withLock(\.callCount)
    }
    var fetchDataArgValues: [AnyObject] {
        return fetchDataState.withLock(\.argValues).map(\.value)
    }
    var fetchDataHandler: (@Sendable (AnyObject) async -> (Int))? {
        get { fetchDataState.withLock(\.handler) }
        set { fetchDataState.withLock { $0.handler = newValue } }
    }
    func fetchData(_ id: AnyObject) async -> Int {
        warnIfNotSendable(id)
        let handler = fetchDataState.withLock { state in
            state.callCount += 1
            state.argValues.append(.init(id))
            return state.handler
        }
        if let handler {
            return await handler(id)
        }
        return 0
    }
}
```