### PR TITLE
Avoid duplicated variable under if-macro syntax

### DIFF
--- a/Sources/MockoloFramework/Models/IfMacroModel.swift
+++ b/Sources/MockoloFramework/Models/IfMacroModel.swift
@@ -17,19 +17,19 @@
 final class IfMacroModel: Model {
     let name: String
     let offset: Int64
-    let entities: [Model]
+    let entities: [(String, Model)]
 
     var modelType: ModelType {
         return .macro
     }
 
     var fullName: String {
-        return entities.map {$0.fullName}.joined(separator: "_")
+        return entities.map {$0.0}.joined(separator: "_")
     }
     
     init(name: String,
          offset: Int64,
-         entities: [Model]) {
+         entities: [(String, Model)]) {
         self.name = name
         self.entities = entities
         self.offset = offset

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -254,8 +254,14 @@ extension IfConfigDeclSyntax {
                 }
             }
         }
+        
+        let uniqueSubModels = uniqueEntities(
+            in: subModels,
+            exclude: [:],
+            fullnames: []
+        ).map({ $0 })
 
-        let macroModel = IfMacroModel(name: name, offset: self.offset, entities: subModels)
+        let macroModel = IfMacroModel(name: name, offset: self.offset, entities: uniqueSubModels)
         return (macroModel, attrDesc, hasInit)
     }
 }

--- a/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
+++ b/Sources/MockoloFramework/Templates/IfMacroTemplate.swift
@@ -20,12 +20,12 @@ extension IfMacroModel {
     func applyMacroTemplate(name: String,
                             context: RenderContext,
                             arguments: GenerationArguments,
-                            entities: [Model]) -> String {
+                            entities: [(String, Model)]) -> String {
         let rendered = entities
             .compactMap { model in
-                model.render(
+                model.1.render(
                     context: .init(
-                        overloadingResolvedName: model.name, // FIXME: the name is not resolving overload
+                        overloadingResolvedName: model.0,
                         enclosingType: context.enclosingType,
                         annotatedTypeKind: context.annotatedTypeKind
                     ),

--- a/Tests/TestMacros/FixtureMacro.swift
+++ b/Tests/TestMacros/FixtureMacro.swift
@@ -282,21 +282,27 @@ protocol PresentableListener: AnyObject {
 """
 
 let macroInFuncWithOverloadMock = """
+
+
+
 class PresentableListenerMock: PresentableListener {
     init() { }
+
     #if DEBUG
+
     private(set) var runCallCount = 0
-    var runHandler: ((Int)  -> ())?
-    func run(value: Int)   {
+    var runHandler: ((Int) -> ())?
+    func run(value: Int) {
         runCallCount += 1
         if let runHandler = runHandler {
             runHandler(value)
         }
         
     }
+
     private(set) var runValueCallCount = 0
-    var runValueHandler: ((String)  -> ())?
-    func run(value: String)   {
+    var runValueHandler: ((String) -> ())?
+    func run(value: String) {
         runValueCallCount += 1
         if let runValueHandler = runValueHandler {
             runValueHandler(value)
@@ -305,4 +311,5 @@ class PresentableListenerMock: PresentableListener {
     }
     #endif
 }
+
 """

--- a/Tests/TestMacros/MacroTests.swift
+++ b/Tests/TestMacros/MacroTests.swift
@@ -8,10 +8,8 @@ final class MacroTests: MockoloTestCase {
 
 #if os(macOS)
     func testMacroInFuncWithOverload() {
-        XCTExpectFailure("Resolving overloading in #if is broken.") {
-            verify(srcContent: macroInFuncWithOverload,
-                   dstContent: macroInFuncWithOverloadMock)
-        }
+        verify(srcContent: macroInFuncWithOverload,
+               dstContent: macroInFuncWithOverloadMock)
     }
 #endif
 

--- a/Tests/TestMacros/MacroTests.swift
+++ b/Tests/TestMacros/MacroTests.swift
@@ -1,17 +1,13 @@
-import XCTest
-
 final class MacroTests: MockoloTestCase {
     func testMacroInFunc() {
         verify(srcContent: macroInFunc,
                dstContent: macroInFuncMock)
     }
 
-#if os(macOS)
     func testMacroInFuncWithOverload() {
         verify(srcContent: macroInFuncWithOverload,
                dstContent: macroInFuncWithOverloadMock)
     }
-#endif
 
     func testMacroImports() {
         verify(srcContent: macroImports,


### PR DESCRIPTION
This PR addresses #273 and performs `uniqueEntities` method for IfMacroModel before rendering because entities inside IfMacroModel are not treated as NominalModel's entities.

I think IfMacro support is insufficient yet (see #263  ) but I am focusing to fix #273 in this PR.

- Input

```swift
/// @mockable
protocol PresentableListener: AnyObject {
    #if RELEASE
    func run(value: Int)
    func run(value: String)
    #endif
}
```

- Output

<table>
<thead><tr><th>Before</th><th>After</th></tr></thead>
<tbody>
<tr><td>

```swift
class PresentableListenerMock: PresentableListener {
    init() { }

    #if RELEASE

    private(set) var runCallCount = 0
    var runHandler: ((Int) -> ())?
    func run(value: Int) {
        runCallCount += 1
        if let runHandler = runHandler {
            runHandler(value)
        }
        
    }

    // not supporting overload
    private(set) var runCallCount = 0
    var runHandler: ((String) -> ())?
    func run(value: String) {
        runCallCount += 1
        if let runHandler = runHandler {
            runHandler(value)
        }
        
    }
    #endif
}
```

</td><td>

```swift

class PresentableListenerMock: PresentableListener {
    init() { }

    #if RELEASE

    private(set) var runCallCount = 0
    var runArgValues = [Int]()
    var runHandler: ((Int) -> ())?
    func run(value: Int) {
        runCallCount += 1
        runArgValues.append(value)
        if let runHandler = runHandler {
            runHandler(value)
        }
        
    }

    private(set) var runValueCallCount = 0
    var runValueArgValues = [String]()
    var runValueHandler: ((String) -> ())?
    func run(value: String) {
        runValueCallCount += 1
        runValueArgValues.append(value)
        if let runValueHandler = runValueHandler {
            runValueHandler(value)
        }
        
    }
    #endif
}
``` 

</td></tr>
</tbody></table> 