### PR TITLE
Fix undetectable mock annotations with attributes above.

### DIFF
--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -259,7 +259,7 @@ extension IfConfigDeclSyntax {
             in: subModels,
             exclude: [:],
             fullnames: []
-        ).map({ $0 })
+        ).sorted(path: \.value.offset, fallback: \.key)
 
         let macroModel = IfMacroModel(name: name, offset: self.offset, entities: uniqueSubModels)
         return (macroModel, attrDesc, hasInit)

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -300,7 +300,7 @@ extension ProtocolDeclSyntax: EntityNode {
     }
 
     func annotationMetadata(with annotation: String) -> AnnotationMetadata? {
-        return leadingTrivia.annotationMetadata(with: annotation)
+        return leadingTrivia.annotationMetadata(with: annotation) ?? protocolKeyword.leadingTrivia.annotationMetadata(with: annotation)
     }
 
     var hasBlankInit: Bool {
@@ -358,7 +358,7 @@ extension ClassDeclSyntax: EntityNode {
     }
 
     func annotationMetadata(with annotation: String) -> AnnotationMetadata? {
-        return leadingTrivia.annotationMetadata(with: annotation)
+        return leadingTrivia.annotationMetadata(with: annotation) ?? classKeyword.leadingTrivia.annotationMetadata(with: annotation)
     }
 
     func subContainer(metadata: AnnotationMetadata?, declKind: NominalTypeDeclKind, path: String?, isProcessed: Bool) -> EntityNodeSubContainer {
@@ -670,7 +670,6 @@ final class EntityVisitor: SyntaxVisitor {
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         let metadata = node.annotationMetadata(with: annotation)
-        ?? node.protocolKeyword.leadingTrivia.annotationMetadata(with: annotation)
         if let ent = Entity.node(with: node, filepath: path, isPrivate: node.isPrivate, isFinal: false, metadata: metadata, processed: false) {
             entities.append(ent)
         }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -14,6 +14,7 @@
 //  limitations under the License.
 //
 
+import Algorithms
 import Foundation
 import SwiftSyntax
 import SwiftParser
@@ -300,7 +301,12 @@ extension ProtocolDeclSyntax: EntityNode {
     }
 
     func annotationMetadata(with annotation: String) -> AnnotationMetadata? {
-        return leadingTrivia.annotationMetadata(with: annotation) ?? protocolKeyword.leadingTrivia.annotationMetadata(with: annotation)
+        let trivias = [
+            leadingTrivia,
+            protocolKeyword.leadingTrivia,
+            modifiers.leadingTrivia,
+        ] + attributes.map(\.leadingTrivia)
+        return trivias.firstNonNil { $0.annotationMetadata(with: annotation) }
     }
 
     var hasBlankInit: Bool {
@@ -358,7 +364,12 @@ extension ClassDeclSyntax: EntityNode {
     }
 
     func annotationMetadata(with annotation: String) -> AnnotationMetadata? {
-        return leadingTrivia.annotationMetadata(with: annotation) ?? classKeyword.leadingTrivia.annotationMetadata(with: annotation)
+        let trivias = [
+            leadingTrivia,
+            classKeyword.leadingTrivia,
+            modifiers.leadingTrivia,
+        ] + attributes.map(\.leadingTrivia)
+        return trivias.firstNonNil { $0.annotationMetadata(with: annotation) }
     }
 
     func subContainer(metadata: AnnotationMetadata?, declKind: NominalTypeDeclKind, path: String?, isProcessed: Bool) -> EntityNodeSubContainer {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -670,6 +670,7 @@ final class EntityVisitor: SyntaxVisitor {
 
     override func visit(_ node: ProtocolDeclSyntax) -> SyntaxVisitorContinueKind {
         let metadata = node.annotationMetadata(with: annotation)
+        ?? node.protocolKeyword.leadingTrivia.annotationMetadata(with: annotation)
         if let ent = Entity.node(with: node, filepath: path, isPrivate: node.isPrivate, isFinal: false, metadata: metadata, processed: false) {
             entities.append(ent)
         }
@@ -863,9 +864,9 @@ extension Trivia {
     // See metadata(with:, in:) for more info on the annotation arguments.
     func annotationMetadata(with annotation: String) -> AnnotationMetadata? {
         guard !annotation.isEmpty else { return nil }
+
         var ret: AnnotationMetadata?
-        for i in 0..<count {
-            let trivia = self[i]
+        for trivia in self {
             switch trivia {
             case .docLineComment(let val):
                 ret = metadata(with: annotation, in: val)

--- a/Tests/TestActor/ActorTests.swift
+++ b/Tests/TestActor/ActorTests.swift
@@ -16,6 +16,7 @@ final class ActorTests: MockoloTestCase {
 
     func testAttributeAboveAnnotationComment() {
         verify(srcContent: attributeAboveAnnotationComment,
-               dstContent: attributeAboveAnnotationCommentMock)
+               dstContent: attributeAboveAnnotationCommentMock,
+               declType: .all)
     }
 }

--- a/Tests/TestActor/ActorTests.swift
+++ b/Tests/TestActor/ActorTests.swift
@@ -13,4 +13,9 @@ final class ActorTests: MockoloTestCase {
         verify(srcContent: globalActorProtocol,
                dstContent: globalActorProtocolMock)
     }
+
+    func testAttributeAboveAnnotationComment() {
+        verify(srcContent: attributeAboveAnnotationComment,
+               dstContent: attributeAboveAnnotationCommentMock)
+    }
 }

--- a/Tests/TestActor/FixtureGlobalActor.swift
+++ b/Tests/TestActor/FixtureGlobalActor.swift
@@ -48,14 +48,21 @@ class RootBuildableMock: RootBuildable {
 let attributeAboveAnnotationComment = """
 @MainActor
 /// \(String.mockAnnotation)
-protocol AttributeAboveAnnotationComment {
+protocol AttributeAboveAnnotationCommentProtocol {
+}
+
+@MainActor
+/// \(String.mockAnnotation)
+class AttributeAboveAnnotationCommentClass {
 }
 """
 
 let attributeAboveAnnotationCommentMock = """
-class AttributeAboveAnnotationCommentMock: AttributeAboveAnnotationComment {
+class AttributeAboveAnnotationCommentProtocolMock: AttributeAboveAnnotationCommentProtocol {
     init() { }
+}
 
-
+class AttributeAboveAnnotationCommentClassMock: AttributeAboveAnnotationCommentClass {
+    init() { }
 }
 """

--- a/Tests/TestActor/FixtureGlobalActor.swift
+++ b/Tests/TestActor/FixtureGlobalActor.swift
@@ -43,3 +43,19 @@ class RootBuildableMock: RootBuildable {
     }
 }
 """
+
+
+let attributeAboveAnnotationComment = """
+@MainActor
+/// \(String.mockAnnotation)
+protocol AttributeAboveAnnotationComment {
+}
+"""
+
+let attributeAboveAnnotationCommentMock = """
+class AttributeAboveAnnotationCommentMock: AttributeAboveAnnotationComment {
+    init() { }
+
+
+}
+"""

--- a/Tests/TestActor/FixtureGlobalActor.swift
+++ b/Tests/TestActor/FixtureGlobalActor.swift
@@ -48,21 +48,30 @@ class RootBuildableMock: RootBuildable {
 let attributeAboveAnnotationComment = """
 @MainActor
 /// \(String.mockAnnotation)
-protocol AttributeAboveAnnotationCommentProtocol {
+protocol P0 {
 }
 
 @MainActor
 /// \(String.mockAnnotation)
-class AttributeAboveAnnotationCommentClass {
+@available(iOS 18.0, *) protocol P1 {
+}
+
+@MainActor
+/// \(String.mockAnnotation)
+public class C0 {
 }
 """
 
 let attributeAboveAnnotationCommentMock = """
-class AttributeAboveAnnotationCommentProtocolMock: AttributeAboveAnnotationCommentProtocol {
+class P0Mock: P0 {
     init() { }
 }
 
-class AttributeAboveAnnotationCommentClassMock: AttributeAboveAnnotationCommentClass {
+class P1Mock: P1 {
     init() { }
+}
+
+public class C0Mock: C0 {
+    public init() { }
 }
 """


### PR DESCRIPTION
mockolo cannot detect the mock annotation in code like the following:

```swift
@MainActor
/// @mockable
protocol P {
}
```
This PR fixes this issue.