### PR TITLE
Add labels to history tuple array

### DIFF
--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -18,7 +18,7 @@ final class ArgumentsHistoryModel: Model {
     let name: String
     let capturedValueType: SwiftType
     let offset: Int64 = .max
-    let capturableParams: [(String, SwiftType)]
+    let capturableParamLabels: [String]
     let isHistoryAnnotated: Bool
 
     var modelType: ModelType {
@@ -35,10 +35,10 @@ final class ArgumentsHistoryModel: Model {
         self.name = name + .argsHistorySuffix
         self.isHistoryAnnotated = isHistoryAnnotated
 
-        self.capturableParams = capturables.map { ($0.name.safeName, $0.type) }
-        
+        self.capturableParamLabels = capturables.map(\.name.safeName)
+
         let genericTypeNameList = genericTypeParams.map(\.name)
-        self.capturedValueType = SwiftType.toArgumentsCaptureType(with: capturableParams.map(\.1), typeParams: genericTypeNameList)
+        self.capturedValueType = SwiftType.toArgumentsCaptureType(with: capturables.map(\.type), typeParams: genericTypeNameList)
     }
     
     func enable(force: Bool) -> Bool {
@@ -56,11 +56,11 @@ final class ArgumentsHistoryModel: Model {
             return nil
         }
         
-        switch capturableParams.count {
+        switch capturableParamLabels.count {
         case 1:
-            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append(\(capturableParams[0].0))"
+            return "\(overloadingResolvedName)\(String.argsHistorySuffix).append(\(capturableParamLabels[0]))"
         case 2...:
-            let paramNamesStr = capturableParams.map(\.0).joined(separator: ", ")
+            let paramNamesStr = capturableParamLabels.joined(separator: ", ")
             return "\(overloadingResolvedName)\(String.argsHistorySuffix).append((\(paramNamesStr)))"
         default:
             fatalError("paramNames must not be empty.")

--- a/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
+++ b/Sources/MockoloFramework/Models/ArgumentsHistoryModel.swift
@@ -37,8 +37,10 @@ final class ArgumentsHistoryModel: Model {
 
         self.capturableParamLabels = capturables.map(\.name.safeName)
 
-        let genericTypeNameList = genericTypeParams.map(\.name)
-        self.capturedValueType = SwiftType.toArgumentsCaptureType(with: capturables.map(\.type), typeParams: genericTypeNameList)
+        self.capturedValueType = SwiftType.toArgumentsCaptureType(
+            with: capturables.map { ($0.name, $0.type) },
+            typeParams: genericTypeParams.map(\.name)
+        )
     }
     
     func enable(force: Bool) -> Bool {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -489,7 +489,9 @@ extension SubscriptDeclSyntax {
     func model(with acl: String, declKind: NominalTypeDeclKind, processed: Bool) -> Model {
         let isStatic = self.modifiers.isStatic
 
-        let params = self.parameterClause.parameters.compactMap { $0.model(inInit: false, declKind: declKind) }
+        let params = self.parameterClause.parameters.enumerated().compactMap {
+            $1.model(inInit: false, declKind: declKind, index: $0)
+        }
         let genericTypeParams = self.genericParameterClause?.parameters.compactMap { $0.model(inInit: false) } ?? []
         let genericWhereClause = self.genericWhereClause?.description
 
@@ -518,7 +520,9 @@ extension FunctionDeclSyntax {
     func model(with acl: String, declKind: NominalTypeDeclKind, funcsWithArgsHistory: [String]?, customModifiers: [String : Modifier]?, processed: Bool) -> Model {
         let isStatic = self.modifiers.isStatic
 
-        let params = self.signature.parameterClause.parameters.compactMap { $0.model(inInit: false, declKind: declKind) }
+        let params = self.signature.parameterClause.parameters.enumerated().compactMap {
+            $1.model(inInit: false, declKind: declKind, index: $0)
+        }
         let genericTypeParams = self.genericParameterClause?.parameters.compactMap { $0.model(inInit: false) } ?? []
         let genericWhereClause = self.genericWhereClause?.description
 
@@ -560,7 +564,9 @@ extension InitializerDeclSyntax {
     func model(with acl: String, declKind: NominalTypeDeclKind, processed: Bool) -> Model {
         let requiredInit = isRequired(with: declKind)
 
-        let params = self.signature.parameterClause.parameters.compactMap { $0.model(inInit: true, declKind: declKind) }
+        let params = self.signature.parameterClause.parameters.enumerated().compactMap {
+            $1.model(inInit: true, declKind: declKind, index: $0)
+        }
         let genericTypeParams = self.genericParameterClause?.parameters.compactMap { $0.model(inInit: true) } ?? []
         let genericWhereClause = self.genericWhereClause?.description
 
@@ -599,7 +605,7 @@ extension GenericParameterSyntax {
 }
 
 extension FunctionParameterSyntax {
-    func model(inInit: Bool, declKind: NominalTypeDeclKind) -> ParamModel {
+    func model(inInit: Bool, declKind: NominalTypeDeclKind, index: Int) -> ParamModel {
         var label = ""
         var name = ""
         // Get label and name of args
@@ -607,10 +613,13 @@ extension FunctionParameterSyntax {
         if let second = self.secondName?.text {
             label = first
             name = second
+            if name == "_" {
+                name = "_\(index)"
+            }
         } else {
             if first == "_" {
                 label = first
-                name = first + "arg"
+                name = "_\(index)"
             } else {
                 name = first
             }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -606,21 +606,23 @@ extension GenericParameterSyntax {
 
 extension FunctionParameterSyntax {
     func model(inInit: Bool, declKind: NominalTypeDeclKind, index: Int) -> ParamModel {
-        var label = ""
-        var name = ""
+        let label: String
+        let name: String
         // Get label and name of args
         let first = self.firstName.text
         if let second = self.secondName?.text {
             label = first
-            name = second
-            if name == "_" {
+            if second == "_" {
                 name = "_\(index)"
+            } else {
+                name = second
             }
         } else {
             if first == "_" {
                 label = first
                 name = "_\(index)"
             } else {
+                label = ""
                 name = first
             }
         }

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -79,7 +79,7 @@ extension MethodModel {
                 if context.requiresSendable {
                     let paramNamesStr: String?
                     if let argsHistory = model.argsHistory, argsHistory.enable(force: arguments.enableFuncArgsHistory) {
-                        paramNamesStr = argsHistory.capturableParams.map(\.0).joined(separator: ", ")
+                        paramNamesStr = argsHistory.capturableParamLabels.joined(separator: ", ")
                     } else {
                         paramNamesStr = nil
                     }

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -542,9 +542,11 @@ public final class SwiftType {
         return SwiftType(typeStr, cast: returnTypeCast)
     }
     
-    static func toArgumentsCaptureType(with params: [SwiftType], typeParams: [String]) -> SwiftType {
+    static func toArgumentsCaptureType(with params: [(label: String, type: SwiftType)], typeParams: [String]) -> SwiftType {
+        assert(!params.isEmpty)
+
         // Expected only history capturable types.
-        let displayableParamTypes = params.compactMap { (subtype: SwiftType) -> String? in
+        let displayableParamTypes = params.map { $0.type }.compactMap { (subtype: SwiftType) -> String? in
             var processedType = subtype.processTypeParams(with: typeParams)
             
             if subtype.isInOut {
@@ -556,13 +558,15 @@ public final class SwiftType {
             
             return processedType
         }
-        
-        let displayableParamStr = displayableParamTypes.joined(separator: ", ")
 
         if displayableParamTypes.count >= 2 {
+            let displayableParamStr = zip(params.map(\.label), displayableParamTypes).map {
+                "\($0): \($1)"
+            }
+                .joined(separator: ", ")
             return SwiftType("(\(displayableParamStr))")
         } else {
-            return SwiftType(displayableParamStr)
+            return SwiftType(displayableParamTypes[0])
         }
     }
 

--- a/Tests/TestArgumentsHistory/ArgumentsHistoryTests.swift
+++ b/Tests/TestArgumentsHistory/ArgumentsHistoryTests.swift
@@ -66,4 +66,10 @@ class ArgumentsHistoryTests: MockoloTestCase {
                dstContent: argumentsHistoryStaticCase.expected._source,
                enableFuncArgsHistory: true)
     }
+
+    func testArgumentsHistoryLabels() {
+        verify(srcContent: argumentsHistoryLabels._source,
+               dstContent: argumentsHistoryLabels.expected._source,
+               enableFuncArgsHistory: true)
+    }
 }

--- a/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
+++ b/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
@@ -34,7 +34,7 @@
             }
 
             private(set) var bazFuncCallCount = 0
-            var bazFuncArgValues = [(String, Float)]()
+            var bazFuncArgValues = [(arg: String, default: Float)]()
             var bazFuncHandler: ((String, Float) -> ())?
             func bazFunc(arg: String, default: Float) {
                 bazFuncCallCount += 1
@@ -83,7 +83,7 @@
             }
 
             private(set) var bazFuncCallCount = 0
-            var bazFuncArgValues = [(String, Float)]()
+            var bazFuncArgValues = [(arg: String, default: Float)]()
             var bazFuncHandler: ((String, Float) -> ())?
             func bazFunc(arg: String, default: Float) {
                 bazFuncCallCount += 1
@@ -159,7 +159,7 @@
             }
 
             private(set) var quuxFuncCallCount = 0
-            var quuxFuncArgValues = [(String, Float)]()
+            var quuxFuncArgValues = [(val1: String, val2: Float)]()
             var quuxFuncHandler: ((String, Float) -> ())?
             func quuxFunc(val1: String, val2: Float) {
                 quuxFuncCallCount += 1
@@ -200,7 +200,7 @@ let argumentsHistorySimpleCaseMock = """
             }
 
             private(set) var barFuncCallCount = 0
-            var barFuncArgValues = [((bar1: Int, String), (bar3: Int, bar4: String))]()
+            var barFuncArgValues = [(val1: (bar1: Int, String), val2: (bar3: Int, bar4: String))]()
             var barFuncHandler: (((bar1: Int, String), (bar3: Int, bar4: String)) -> ())?
             func barFunc(val1: (bar1: Int, String), val2: (bar3: Int, bar4: String)) {
                 barFuncCallCount += 1
@@ -289,7 +289,7 @@ let argumentsHistorySimpleCaseMock = """
             init() { }
             
             private(set) var fooFuncCallCount = 0
-            var fooFuncArgValues = [(Any, Any?)]()
+            var fooFuncArgValues = [(val1: Any, val2: Any?)]()
             var fooFuncHandler: ((Any, Any?) -> ())?
             func fooFunc<T: StringProtocol>(val1: T, val2: T?) {
                 fooFuncCallCount += 1

--- a/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
+++ b/Tests/TestArgumentsHistory/FixtureArgumentsHistory.swift
@@ -173,9 +173,6 @@
     }
 }
 
-let argumentsHistorySimpleCaseMock = """
-"""
-
 @Fixture enum argumentsHistoryTupleCase {
     /// @mockable(history: fooFunc = true)
     protocol Foo {
@@ -473,6 +470,44 @@ let argumentsHistorySimpleCaseMock = """
                 if let fooFuncHandler = fooFuncHandler {
                     fooFuncHandler(val)
                 }
+            }
+        }
+    }
+}
+
+@Fixture enum argumentsHistoryLabels {
+    /// @mockable
+    protocol Foo {
+        func foo(arg0: Int, _ arg1: Double, first throws: String)
+        func bar(_: Int, _: Void, _ _: Void)
+    }
+
+    @Fixture enum expected {
+        class FooMock: Foo {
+            init() { }
+
+            private(set) var fooCallCount = 0
+            var fooArgValues = [(arg0: Int, arg1: Double, throws: String)]()
+            var fooHandler: ((Int, Double, String) -> ())?
+            func foo(arg0: Int, _ arg1: Double, first throws: String) {
+                fooCallCount += 1
+                fooArgValues.append((arg0, arg1, `throws`))
+                if let fooHandler = fooHandler {
+                    fooHandler(arg0, arg1, `throws`)
+                }
+
+            }
+
+            private(set) var barCallCount = 0
+            var barArgValues = [(_0: Int, _1: Void, _2: Void)]()
+            var barHandler: ((Int, Void, Void) -> ())?
+            func bar(_ _0: Int, _ _1: Void, _ _2: Void) {
+                barCallCount += 1
+                barArgValues.append((_0, _1, _2))
+                if let barHandler = barHandler {
+                    barHandler(_0, _1, _2)
+                }
+
             }
         }
     }

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -37,11 +37,11 @@ public final class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
         return ""
     }
 
-    private let updateArg0State = MockoloMutex(MockoloHandlerState<(Any, AnyObject), @Sendable (Any, AnyObject) async throws -> ()>())
+    private let updateArg0State = MockoloMutex(MockoloHandlerState<(arg0: Any, arg1: AnyObject), @Sendable (Any, AnyObject) async throws -> ()>())
     public var updateArg0CallCount: Int {
         return updateArg0State.withLock(\.callCount)
     }
-    public var updateArg0ArgValues: [(Any, AnyObject)] {
+    public var updateArg0ArgValues: [(arg0: Any, arg1: AnyObject)] {
         return updateArg0State.withLock(\.argValues).map(\.value)
     }
     public var updateArg0Handler: (@Sendable (Any, AnyObject) async throws -> ())? {


### PR DESCRIPTION
Issue: https://github.com/uber/mockolo/issues/283

Add labels to the history property of mock function arguments.
These labels enhance the readability of the test code.

Since access by index remains possible even with the addition of labels, I believe this change does not break backward compatibility.

```swift
let t = (a: 0, b: 1)
t.0 // 0
t.a // 0
```