### PR TITLE
Avoid Special Handling of the "Unknown" Type Name

### DIFF
--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -24,7 +24,7 @@ public enum MethodKind: Equatable {
 
 final class MethodModel: Model {
     let name: String
-    let returnType: SwiftType
+    let returnType: SwiftType?
     let accessLevel: String
     let kind: MethodKind
     let offset: Int64
@@ -114,10 +114,11 @@ final class MethodModel: Model {
             args.append(genericWhereClauseToSignatureComponent)
         }
         args.append(contentsOf: paramTypes.map(\.displayName))
-        var displayType = self.returnType.displayName
-        let capped = min(displayType.count, 32)
-        displayType.removeLast(displayType.count-capped)
-        args.append(displayType)
+        if var displayType = self.returnType?.displayName {
+            let capped = min(displayType.count, 32)
+            displayType.removeLast(displayType.count-capped)
+            args.append(displayType)
+        }
         args.append(self.staticKind)
         let ret = args.filter{ arg in !arg.isEmpty }
         return ret
@@ -145,11 +146,11 @@ final class MethodModel: Model {
                             params: params.map { ($0.name, $0.type) },
                             isAsync: isAsync,
                             throwing: throwing,
-                            returnType: returnType)
+                            returnType: returnType ?? .init(.voidType))
     }
 
     init(name: String,
-         typeName: String,
+         typeName: String?,
          kind: MethodKind,
          acl: String,
          genericTypeParams: [ParamModel],
@@ -165,7 +166,7 @@ final class MethodModel: Model {
          modelDescription: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
-        self.returnType = SwiftType(typeName.trimmingCharacters(in: .whitespaces))
+        self.returnType = typeName.map { SwiftType($0.trimmingCharacters(in: .whitespaces)) }
         self.isAsync = isAsync
         self.throwing = throwing
         self.offset = offset

--- a/Sources/MockoloFramework/Models/ParamModel.swift
+++ b/Sources/MockoloFramework/Models/ParamModel.swift
@@ -85,7 +85,7 @@ final class ParamModel: Model {
         context: RenderContext,
         arguments: GenerationArguments
     ) -> String? {
-        return applyParamTemplate(name: name, label: label, type: type, inInit: inInit)
+        return applyParamTemplate(name: name, label: label, type: type, inInit: inInit, isGeneric: isGeneric)
     }
 }
 

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -13,7 +13,7 @@ final class VariableModel: Model {
     }
 
     let name: String
-    let type: SwiftType
+    let type: SwiftType?
     let offset: Int64
     let accessLevel: String
     let attributes: [String]?
@@ -39,14 +39,14 @@ final class VariableModel: Model {
     }
 
     var underlyingName: String {
-        if type.defaultVal() == nil {
+        if type?.defaultVal() == nil {
             return "_\(name)"
         }
         return name
     }
 
     init(name: String,
-         type: SwiftType,
+         type: SwiftType?,
          acl: String?,
          isStatic: Bool,
          storageKind: MockStorageKind,
@@ -89,11 +89,15 @@ final class VariableModel: Model {
             if let propertyWrapper = propertyWrapper, !modelDescription.contains(propertyWrapper) {
                 prefix = "\(propertyWrapper) "
             }
-            if shouldOverride, !name.isGenerated(type: type) {
+            if let type, shouldOverride, !name.isGenerated(type: type) {
                 prefix += "\(String.override) "
             }
 
             return prefix + modelDescription
+        }
+
+        guard let type else {
+            return nil
         }
 
         if !arguments.disableCombineDefaultValues {

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -531,7 +531,7 @@ extension FunctionDeclSyntax {
         let genericWhereClause = self.genericWhereClause?.description
 
         let funcmodel = MethodModel(name: self.name.description,
-                                    typeName: self.signature.returnClause?.type.description ?? .voidType,
+                                    typeName: self.signature.returnClause?.type.description,
                                     kind: .funcKind,
                                     acl: acl,
                                     genericTypeParams: genericTypeParams,
@@ -575,7 +575,7 @@ extension InitializerDeclSyntax {
         let genericWhereClause = self.genericWhereClause?.description
 
         return MethodModel(name: "init",
-                           typeName: .voidType,
+                           typeName: nil,
                            kind: .initKind(required: requiredInit, override: declKind == .class),
                            acl: acl,
                            genericTypeParams: genericTypeParams,

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -430,7 +430,7 @@ extension VariableDeclSyntax {
 
         // Need to access pattern bindings to get name, type, and other info of a var decl
         let varmodels = self.bindings.compactMap { (v: PatternBindingSyntax) -> Model in
-            let name = v.pattern.firstToken(viewMode: .sourceAccurate)?.text ?? String.unknownVal
+            let name = v.pattern.trimmedDescription
             var typeName = ""
             var potentialInitParam = false
 

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -431,7 +431,7 @@ extension VariableDeclSyntax {
         // Need to access pattern bindings to get name, type, and other info of a var decl
         let varmodels = self.bindings.compactMap { (v: PatternBindingSyntax) -> Model in
             let name = v.pattern.trimmedDescription
-            var typeName = ""
+            var typeName = String.voidType
             var potentialInitParam = false
 
             // Get the type info and whether it can be a var param for an initializer
@@ -531,7 +531,7 @@ extension FunctionDeclSyntax {
         let genericWhereClause = self.genericWhereClause?.description
 
         let funcmodel = MethodModel(name: self.name.description,
-                                    typeName: self.signature.returnClause?.type.description ?? "",
+                                    typeName: self.signature.returnClause?.type.description ?? .voidType,
                                     kind: .funcKind,
                                     acl: acl,
                                     genericTypeParams: genericTypeParams,
@@ -575,7 +575,7 @@ extension InitializerDeclSyntax {
         let genericWhereClause = self.genericWhereClause?.description
 
         return MethodModel(name: "init",
-                           typeName: "",
+                           typeName: .voidType,
                            kind: .initKind(required: requiredInit, override: declKind == .class),
                            acl: acl,
                            genericTypeParams: genericTypeParams,
@@ -599,7 +599,7 @@ extension GenericParameterSyntax {
     func model(inInit: Bool) -> ParamModel {
         return ParamModel(label: "",
                           name: self.name.text,
-                          type: SwiftType(self.inheritedType?.trimmedDescription ?? ""),
+                          type: SwiftType(self.inheritedType?.trimmedDescription ?? .voidType),
                           isGeneric: true,
                           inInit: inInit,
                           needsVarDecl: false,

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -431,7 +431,7 @@ extension VariableDeclSyntax {
         // Need to access pattern bindings to get name, type, and other info of a var decl
         let varmodels = self.bindings.compactMap { (v: PatternBindingSyntax) -> Model in
             let name = v.pattern.trimmedDescription
-            var typeName = String.voidType
+            var typeName: String?
             var potentialInitParam = false
 
             // Get the type info and whether it can be a var param for an initializer
@@ -473,7 +473,7 @@ extension VariableDeclSyntax {
             }
 
             return VariableModel(name: name,
-                                 type: SwiftType(typeName),
+                                 type: typeName.map { SwiftType($0) },
                                  acl: acl,
                                  isStatic: isStatic,
                                  storageKind: storageKind,

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -53,7 +53,7 @@ extension ClosureModel {
     
     
     private func renderReturnDefaultStatement(name: String, type: SwiftType) -> String {
-        guard !type.isUnknown else { return "" }
+        guard !type.isVoid else { return "" }
         
         if let result = type.defaultVal() {
             if result.isEmpty {

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -61,10 +61,10 @@ extension MethodModel {
                     return arg.name.safeName
                 }.joined(separator: ", ")
 
-                let defaultVal = model.returnType.defaultVal() // ?? "nil"
+                let defaultVal = model.returnType?.defaultVal()
 
                 var mockReturn = ".error"
-                if model.returnType.typeName.isEmpty {
+                if model.returnType?.isVoid ?? true {
                     mockReturn = ".void"
                 } else if let val = defaultVal {
                     mockReturn = ".val(\(val))"
@@ -157,10 +157,10 @@ extension MethodModel {
         }
 
         var returnClause: String {
-            if model.returnType.isVoid {
-                return ""
+            if let returnType = model.returnType {
+                return "-> \(returnType.typeName) "
             } else {
-                return "-> \(model.returnType.typeName) "
+                return ""
             }
         }
 

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -157,8 +157,11 @@ extension MethodModel {
         }
 
         var returnClause: String {
-            let returnTypeName = model.returnType.isUnknown ? "" : model.returnType.typeName
-            return returnTypeName.isEmpty ? "" : "-> \(returnTypeName) "
+            if model.returnType.isVoid {
+                return ""
+            } else {
+                return "-> \(model.returnType.typeName) "
+            }
         }
 
         var handlerVarName: String {

--- a/Sources/MockoloFramework/Templates/NominalTemplate.swift
+++ b/Sources/MockoloFramework/Templates/NominalTemplate.swift
@@ -148,17 +148,21 @@ extension NominalModel {
         if needParamedInit {
             var paramsAssign = ""
             let params = initParamCandidates
-                .map { (element: VariableModel) -> String in
-                    if let val = element.type.defaultVal(with: element.rxTypes, overrideKey: element.name, isInitParam: true) {
-                        return "\(element.name): \(element.type.typeName) = \(val)"
+                .compactMap { (element: VariableModel) -> String? in
+                    if let val = element.type?.defaultVal(with: element.rxTypes, overrideKey: element.name, isInitParam: true) {
+                        return "\(element.name): \(element.type!.typeName) = \(val)"
                     }
-                    var prefix = ""
-                    if element.type.hasClosure {
-                        if !element.type.isOptional {
-                            prefix = String.escaping + " "
+                    if let elementType = element.type {
+                        var prefix = ""
+                        if elementType.hasClosure == true {
+                            if !elementType.isOptional {
+                                prefix = String.escaping + " "
+                            }
                         }
+                        return "\(element.name): \(prefix)\(elementType.typeName)"
+                    } else {
+                        return nil
                     }
-                    return "\(element.name): \(prefix)\(element.type.typeName)"
                 }
                 .joined(separator: ", ")
 

--- a/Sources/MockoloFramework/Templates/ParamTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ParamTemplate.swift
@@ -20,15 +20,21 @@ extension ParamModel {
     func applyParamTemplate(name: String,
                             label: String,
                             type: SwiftType,
-                            inInit: Bool) -> String {
+                            inInit: Bool,
+                            isGeneric: Bool) -> String {
         var result = name
         if !label.isEmpty {
             result = "\(label) \(name)"
         }
-        if !type.isUnknown {
+        if isGeneric {
+            // FIXME: `type` is used as a generic constraint
+            if !type.isVoid {
+                result = "\(result): \(type.typeName)"
+            }
+        } else {
             result = "\(result): \(type.typeName)"
         }
-        
+
         if inInit, let defaultVal = type.defaultVal() {
             result = "\(result) = \(defaultVal)"
         }
@@ -36,7 +42,6 @@ extension ParamModel {
     }
 
     func applyVarTemplate(type: SwiftType) -> String {
-        assert(!type.isUnknown)
         let vardecl = "\(1.tab)private var \(underlyingName): \(type.underlyingType)"
         return vardecl
     }

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -168,14 +168,14 @@ extension VariableModel {
 
             var template = "\n"
             var isWrapperPropertyOptionalOrForceUnwrapped = false
-            if let publishedAliasModel = wrapperAliasModel {
+            if let publishedAliasModel = wrapperAliasModel, let type = publishedAliasModel.type {
                 // If the property required by the protocol/class cannot be optional, the wrapper property will be the underlyingProperty
                 // i.e. @Published var _myType: MyType!
-                let wrapperPropertyDefaultValue = publishedAliasModel.type.defaultVal()
+                let wrapperPropertyDefaultValue = type.defaultVal()
                 if wrapperPropertyDefaultValue == nil {
                     wrapperPropertyName = "_\(wrapperPropertyName)"
                 }
-                isWrapperPropertyOptionalOrForceUnwrapped = wrapperPropertyDefaultValue == nil || publishedAliasModel.type.isOptional
+                isWrapperPropertyOptionalOrForceUnwrapped = wrapperPropertyDefaultValue == nil || type.isOptional
             }
 
             var mapping = ""

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -47,6 +47,7 @@ extension String {
     static let mockType = "protocol"
     static let prefix = "prefix"
     static let anyType = "Any"
+    static let voidType = "()"
     static let neverType = "Never"
     static let any = "any"
     static let some = "some"

--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -45,7 +45,6 @@ extension String {
     static let override = "override"
     static let privateSet = "private(set)"
     static let mockType = "protocol"
-    static let unknownVal = "Unknown"
     static let prefix = "prefix"
     static let anyType = "Any"
     static let neverType = "Never"
@@ -170,7 +169,7 @@ extension String {
 
 
     func canBeInitParam(type: String, isStatic: Bool) -> Bool {
-        return !(isStatic || type == .unknownVal || type.hasPrefix(.anyPublisher) || (type.hasSuffix("?") && type.contains(String.closureArrow)) ||  isGenerated(type: SwiftType(type)))
+        return !(isStatic || type.hasPrefix(.anyPublisher) || (type.hasSuffix("?") && type.contains(String.closureArrow)) ||  isGenerated(type: SwiftType(type)))
     }
 
     func isGenerated(type: SwiftType) -> Bool {

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -49,10 +49,6 @@ public final class SwiftType {
         return typeName.hasPrefix(.rxObservableLeftAngleBracket) || typeName.hasPrefix(.observableLeftAngleBracket)
     }
 
-    var isUnknown: Bool {
-        return typeName.isEmpty
-    }
-
     var isOptional: Bool {
         if !typeName.hasSuffix("?") {
             return false
@@ -178,7 +174,7 @@ public final class SwiftType {
     }
 
     var isIdentifier: Bool {
-        if isUnknown {
+        if isVoid {
             return false
         }
 

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -29,6 +29,7 @@ public final class SwiftType {
     var cachedDefaultVal: String?
 
     init(_ type: String, cast: String? = nil){
+        assert(!type.isEmpty)
         self.typeName = type
         self.cast = cast
     }
@@ -197,7 +198,7 @@ public final class SwiftType {
     }
 
     var isVoid: Bool {
-        return typeName.isEmpty || typeName == "()" || typeName == "Void"
+        return typeName == "()" || typeName == "Void"
     }
 
     var hasValidBrackets: Bool {
@@ -524,8 +525,10 @@ public final class SwiftType {
             returnTypeCast = " as! " + String.`Self`
         }
 
-        if !(SwiftType(displayableReturnType).isSingular || SwiftType(displayableReturnType).isOptional) {
-            displayableReturnType = "(\(displayableReturnType))"
+        if !SwiftType(displayableReturnType).isVoid {
+            if !(SwiftType(displayableReturnType).isSingular || SwiftType(displayableReturnType).isOptional) {
+                displayableReturnType = "(\(displayableReturnType))"
+            }
         }
 
         let suffixStr = applyFunctionSuffixTemplate(

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -29,7 +29,7 @@ public final class SwiftType {
     var cachedDefaultVal: String?
 
     init(_ type: String, cast: String? = nil){
-        self.typeName = type == .unknownVal ? "" : type
+        self.typeName = type
         self.cast = cast
     }
 
@@ -50,7 +50,7 @@ public final class SwiftType {
     }
 
     var isUnknown: Bool {
-        return typeName.isEmpty || typeName == String.unknownVal
+        return typeName.isEmpty
     }
 
     var isOptional: Bool {
@@ -174,7 +174,7 @@ public final class SwiftType {
     }
 
     var displayName: String {
-        return typeName.displayableComponents.map{$0 == .unknownVal ? "" : $0.capitalizeFirstLetter}.joined()
+        return typeName.displayableComponents.map(\.capitalizeFirstLetter).joined()
     }
 
     var isIdentifier: Bool {


### PR DESCRIPTION
Fix the handling of the type name "Unknown".
Previously, using "Unknown" as a type name would trigger special treatment and lead to unintended behavior.

Stop using empty value as `SwiftType`, it has implicit behavior depending its value. Use void type when representing empty return value.