### PR TITLE
Remove `cast` property from `SwiftType`

### DIFF
--- a/Sources/MockoloFramework/Models/ClosureModel.swift
+++ b/Sources/MockoloFramework/Models/ClosureModel.swift
@@ -40,7 +40,7 @@ final class ClosureModel: Model {
         self.funcReturnType = returnType
     }
 
-    func type(enclosingType: SwiftType, requiresSendable: Bool) -> SwiftType {
+    func type(enclosingType: SwiftType, requiresSendable: Bool) -> (type: SwiftType, cast: String?) {
         return SwiftType.toClosureType(
             params: params.map(\.1),
             typeParams: genericTypeNames,
@@ -60,7 +60,9 @@ final class ClosureModel: Model {
               let enclosingType = context.enclosingType else {
             return nil
         }
-        return applyClosureTemplate(type: type(enclosingType: enclosingType, requiresSendable: context.requiresSendable),
+        let (type, cast) = self.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable)
+        return applyClosureTemplate(type: type,
+                                    cast: cast,
                                     name: overloadingResolvedName + .handlerSuffix,
                                     params: params,
                                     returnDefaultType: funcReturnType)

--- a/Sources/MockoloFramework/Templates/ClosureTemplate.swift
+++ b/Sources/MockoloFramework/Templates/ClosureTemplate.swift
@@ -18,6 +18,7 @@ import Foundation
 
 extension ClosureModel {
     func applyClosureTemplate(type: SwiftType,
+                              cast: String?,
                               name: String,
                               params: [(String, SwiftType)],
                               returnDefaultType: SwiftType) -> String {
@@ -45,7 +46,7 @@ extension ClosureModel {
 
         return """
         \(2.tab)if let \(name) = \(name) {
-        \(3.tab)\(returnStr)\(prefix)\(name)(\(handlerParamValsStr))\(type.cast ?? "")
+        \(3.tab)\(returnStr)\(prefix)\(name)(\(handlerParamValsStr))\(cast ?? "")
         \(2.tab)}
         \(2.tab)\(handlerReturnDefault)
         """

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -53,7 +53,7 @@ extension MethodModel {
             let body: String
             if arguments.useTemplateFunc
                 && !model.throwing.hasError
-                && (handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).cast?.isEmpty ?? false) {
+                && (handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).cast == nil) {
                 let handlerParamValsStr = model.params.map { (arg) -> String in
                     if arg.type.typeName.hasPrefix(String.autoclosure) {
                         return arg.name.safeName + "()"
@@ -180,7 +180,7 @@ extension MethodModel {
         var stateVarDecl: String? {
             guard context.requiresSendable else { return nil }
 
-            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).typeName
+            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).type.typeName
             let argumentsTupleType: String
             if let argsHistory = model.argsHistory, argsHistory.enable(force: arguments.enableFuncArgsHistory) {
                 argumentsTupleType = argsHistory.capturedValueType.typeName
@@ -230,7 +230,7 @@ extension MethodModel {
         }
 
         var handlerVarDecl: String {
-            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).typeName // ?? "Any"
+            let handlerType = handler.type(enclosingType: enclosingType, requiresSendable: context.requiresSendable).type.typeName // ?? "Any"
             let handlerVarType = "(\(handlerType))?"
             if !context.requiresSendable {
                 return "\(1.tab)\(declModifiers)var \(handlerVarName): \(handlerVarType)"

--- a/Sources/MockoloFramework/Utils/TypeParser.swift
+++ b/Sources/MockoloFramework/Utils/TypeParser.swift
@@ -25,12 +25,10 @@ fileprivate var validIdentifierChars: CharacterSet = {
 /// Decl(e.g. class/struct/protocol/enum) or return type (e.g. var/func)
 public final class SwiftType {
     let typeName: String
-    let cast: String?
     var cachedDefaultVal: String?
 
-    init(_ type: String, cast: String? = nil){
+    init(_ type: String){
         self.typeName = type == .unknownVal ? "" : type
-        self.cast = cast
     }
 
     var isInOut: Bool {
@@ -490,7 +488,7 @@ public final class SwiftType {
         returnType: SwiftType,
         encloser: SwiftType,
         requiresSendable: Bool
-    ) -> SwiftType {
+    ) -> (type: SwiftType, cast: String?) {
         let displayableParamTypes = params.map { (subtype: SwiftType) -> String in
             return subtype.processTypeParams(with: typeParams)
         }
@@ -502,7 +500,7 @@ public final class SwiftType {
 
         var returnAsStr = ""
         var asSuffix = "!"
-        var returnTypeCast = ""
+        var returnTypeCast: String?
         if typeParams.contains(where: { returnComps.contains($0)}) {
             returnAsStr = returnType.typeName
             if returnType.isOptional {
@@ -539,7 +537,7 @@ public final class SwiftType {
 
         let sendableStr = requiresSendable ? "@Sendable " : ""
         let typeStr = "\(sendableStr)(\(displayableParamStr)) \(suffixStr)-> \(displayableReturnType)"
-        return SwiftType(typeStr, cast: returnTypeCast)
+        return (type: SwiftType(typeStr), cast: returnTypeCast)
     }
     
     static func toArgumentsCaptureType(with params: [(label: String, type: SwiftType)], typeParams: [String]) -> SwiftType {


### PR DESCRIPTION
The `SwiftType` has a `cast` property, which is a temporary value used only in certain situations and need not be stored.
Remove it because it is structurally unnatural.