### PR TITLE
Better test verification

### DIFF
--- a/Sources/MockoloTestSupportMacros/Fixture.swift
+++ b/Sources/MockoloTestSupportMacros/Fixture.swift
@@ -56,18 +56,19 @@ struct Fixture: MemberMacro {
             return true
         }
 
+        let baseIndent = Trivia(pieces: node.leadingTrivia.filter(\.isSpaceOrTab))
         let indent = BasicFormat.inferIndentation(of: declaration) ?? .spaces(4)
         var sourceContent = baseItems.trimmedDescription(matching: \.isNewline)
 
         if let imports = argument.imports {
             sourceContent = imports.map {
-                "\(indent)\(indent)import \($0)\n"
+                "\(baseIndent)\(indent)import \($0)\n"
             }.joined() + "\n" + sourceContent
         }
 
         var _sourceInitExpr = StringLiteralExprSyntax(
             multilineContent: sourceContent,
-            endIndent: Trivia(pieces: node.leadingTrivia.filter(\.isSpaceOrTab)) + indent
+            endIndent: baseIndent + indent
         )
         if argument.includesConcurrencyHelpers {
             _sourceInitExpr.segments.append(

--- a/Sources/MockoloTestSupportMacros/Fixture.swift
+++ b/Sources/MockoloTestSupportMacros/Fixture.swift
@@ -5,6 +5,7 @@ import SwiftSyntaxMacros
 struct Fixture: MemberMacro {
     struct Arguments {
         var imports: [String]?
+        var testableImports: [String]?
         var includesConcurrencyHelpers: Bool = false
     }
 
@@ -13,29 +14,45 @@ struct Fixture: MemberMacro {
         guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
             return result
         }
+
         for argument in arguments {
             if argument.label?.text == "includesConcurrencyHelpers",
                 let literal = argument.expression.as(BooleanLiteralExprSyntax.self) {
-                switch literal.literal.text {
-                case "true": result.includesConcurrencyHelpers = true
-                case "false": result.includesConcurrencyHelpers = false
-                default: throw MessageError("Unexpected literal.")
-                }
+                result.includesConcurrencyHelpers = try extract(booleanLiteral: literal)
             }
             if argument.label?.text == "imports",
                let expr = argument.expression.as(ArrayExprSyntax.self) {
-                result.imports = try expr.elements.map { element in
-                    guard let literal = element.expression.as(StringLiteralExprSyntax.self) else {
-                        throw MessageError("Must be string literal.")
-                    }
-                    guard literal.segments.count == 1 else {
-                        throw MessageError("Cannot use string interpolation.")
-                    }
-                    return literal.segments.description
-                }
+                result.imports = try extract(stringLiteralArray: expr)
+            }
+            if argument.label?.text == "testableImports",
+               let expr = argument.expression.as(ArrayExprSyntax.self) {
+                result.testableImports = try extract(stringLiteralArray: expr)
             }
         }
+        if result.includesConcurrencyHelpers && !(result.imports ?? []).contains("Foundation") {
+            result.imports = CollectionOfOne("Foundation") + (result.imports ?? [])
+        }
         return result
+
+        func extract(stringLiteralArray: ArrayExprSyntax) throws -> [String] {
+            return try stringLiteralArray.elements.map { element in
+                guard let literal = element.expression.as(StringLiteralExprSyntax.self) else {
+                    throw MessageError("Must be string literal.")
+                }
+                guard literal.segments.count == 1 else {
+                    throw MessageError("Cannot use string interpolation.")
+                }
+                return literal.segments.description
+            }
+        }
+
+        func extract(booleanLiteral: BooleanLiteralExprSyntax) throws -> Bool {
+            return switch booleanLiteral.literal.text {
+            case "true": true
+            case "false": false
+            default: throw MessageError("Unexpected literal.")
+            }
+        }
     }
 
     static func expansion(
@@ -60,6 +77,11 @@ struct Fixture: MemberMacro {
         let indent = BasicFormat.inferIndentation(of: declaration) ?? .spaces(4)
         var sourceContent = baseItems.trimmedDescription(matching: \.isNewline)
 
+        if let testableImports = argument.testableImports {
+            sourceContent = testableImports.map {
+                "\(baseIndent)\(indent)@testable import \($0)\n"
+            }.joined() + "\n" + sourceContent
+        }
         if let imports = argument.imports {
             sourceContent = imports.map {
                 "\(baseIndent)\(indent)import \($0)\n"

--- a/Sources/MockoloTestSupportMacros/Fixture.swift
+++ b/Sources/MockoloTestSupportMacros/Fixture.swift
@@ -3,12 +3,49 @@ import SwiftSyntax
 import SwiftSyntaxMacros
 
 struct Fixture: MemberMacro {
+    struct Arguments {
+        var imports: [String]?
+        var includesConcurrencyHelpers: Bool = false
+    }
+
+    static func extractArguments(from attribute: AttributeSyntax) throws -> Arguments {
+        var result = Arguments()
+        guard let arguments = attribute.arguments?.as(LabeledExprListSyntax.self) else {
+            return result
+        }
+        for argument in arguments {
+            if argument.label?.text == "includesConcurrencyHelpers",
+                let literal = argument.expression.as(BooleanLiteralExprSyntax.self) {
+                switch literal.literal.text {
+                case "true": result.includesConcurrencyHelpers = true
+                case "false": result.includesConcurrencyHelpers = false
+                default: throw MessageError("Unexpected literal.")
+                }
+            }
+            if argument.label?.text == "imports",
+               let expr = argument.expression.as(ArrayExprSyntax.self) {
+                result.imports = try expr.elements.map { element in
+                    guard let literal = element.expression.as(StringLiteralExprSyntax.self) else {
+                        throw MessageError("Must be string literal.")
+                    }
+                    guard literal.segments.count == 1 else {
+                        throw MessageError("Cannot use string interpolation.")
+                    }
+                    return literal.segments.description
+                }
+            }
+        }
+        return result
+    }
+
     static func expansion(
         of node: AttributeSyntax,
         providingMembersOf declaration: some DeclGroupSyntax,
         conformingTo protocols: [TypeSyntax],
         in context: some MacroExpansionContext
     ) throws -> [DeclSyntax] {
+        let argument = try extractArguments(from: node)
+
         let baseItems = declaration.memberBlock.members.filter { (item: MemberBlockItemSyntax) in
             if let decl = item.decl.asProtocol(WithAttributesSyntax.self) {
                 let isFixtureAnnotated = decl.attributes.contains { (attr: AttributeListSyntax.Element) in
@@ -20,21 +57,37 @@ struct Fixture: MemberMacro {
         }
 
         let indent = BasicFormat.inferIndentation(of: declaration) ?? .spaces(4)
-        let sourceContent = baseItems.trimmedDescription(matching: \.isNewline)
+        var sourceContent = baseItems.trimmedDescription(matching: \.isNewline)
 
-        let varDecl = VariableDeclSyntax(
+        if let imports = argument.imports {
+            sourceContent = imports.map {
+                "\(indent)\(indent)import \($0)\n"
+            }.joined() + "\n" + sourceContent
+        }
+
+        var _sourceInitExpr = StringLiteralExprSyntax(
+            multilineContent: sourceContent,
+            endIndent: Trivia(pieces: node.leadingTrivia.filter(\.isSpaceOrTab)) + indent
+        )
+        if argument.includesConcurrencyHelpers {
+            _sourceInitExpr.segments.append(
+                .expressionSegment(ExpressionSegmentSyntax(
+                    pounds: .rawStringPoundDelimiter("##"),
+                    expressions: [.init(
+                        expression: #""\n\n" + concurrencyHelpers._generatedSource"# as ExprSyntax
+                    )]
+                ))
+            )
+        }
+
+        return [DeclSyntax(VariableDeclSyntax(
             modifiers: [.init(name: .keyword(.static))],
             .let,
             name: "_source",
-            initializer: .init(
-                value: StringLiteralExprSyntax(
-                    multilineContent: sourceContent,
-                    endIndent: Trivia(pieces: node.leadingTrivia.filter(\.isSpaceOrTab)) + indent
-                )
+            initializer: InitializerClauseSyntax(
+                value: _sourceInitExpr
             )
-        )
-
-        return [DeclSyntax(varDecl)]
+        ))]
     }
 }
 

--- a/Sources/MockoloTestSupportMacros/MessageError.swift
+++ b/Sources/MockoloTestSupportMacros/MessageError.swift
@@ -1,0 +1,6 @@
+struct MessageError: Error, CustomStringConvertible {
+    init(_ description: String) {
+        self.description = description
+    }
+    var description: String
+}

--- a/Tests/ConcurrencyHelpers.swift
+++ b/Tests/ConcurrencyHelpers.swift
@@ -69,15 +69,21 @@ final class ConcurrencyHelpersTests: MockoloTestCase {
 
         verify(
             srcContent: src,
-            dstContent: concurrencyHelpers._source.split(separator: "\n").map { line in
-                if ["func", "final class", "struct"].contains(where: {
-                    line.starts(with: $0)
-                }) {
-                    return "fileprivate \(line)"
-                } else {
-                    return String(line)
-                }
-            }.joined(separator: "\n")
+            dstContent: concurrencyHelpers._generatedSource
         )
+    }
+}
+
+extension concurrencyHelpers {
+    static var _generatedSource: String {
+        _source.split(separator: "\n").map { line in
+            if ["func", "final class", "struct"].contains(where: {
+                line.starts(with: $0)
+            }) {
+                return "fileprivate \(line)"
+            } else {
+                return String(line)
+            }
+        }.joined(separator: "\n")
     }
 }

--- a/Tests/ConcurrencyHelpers.swift
+++ b/Tests/ConcurrencyHelpers.swift
@@ -64,12 +64,15 @@ final class ConcurrencyHelpersTests: MockoloTestCase {
 
         verify(
             srcContent: src,
-            dstContent: "import Foundation"
-        )
+            dstContent: """
+            import Foundation
 
-        verify(
-            srcContent: src,
-            dstContent: concurrencyHelpers._generatedSource
+            final class PMock: P, @unchecked Sendable {
+                init() { }
+            }
+            
+            \(concurrencyHelpers._generatedSource)
+            """
         )
     }
 }

--- a/Tests/MockoloTestCase.swift
+++ b/Tests/MockoloTestCase.swift
@@ -54,7 +54,7 @@ class MockoloTestCase: XCTestCase {
         }
     }
 
-    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false) {
+    func verify(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, file: StaticString = #filePath, line: UInt = #line) {
         let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
@@ -63,10 +63,10 @@ class MockoloTestCase: XCTestCase {
             }
             mockList?.append(mock)
         }
-        try? verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues)
+        try? verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues, file: file, line: line)
     }
     
-    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, useMockObservable: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }) {
+    func verifyThrows(srcContent: String, mockContent: String? = nil, dstContent: String, header: String = "", declType: FindTargetDeclType = .protocolType, useTemplateFunc: Bool = false, testableImports: [String] = [], allowSetCallCount: Bool = false, mockFinal: Bool = false, enableFuncArgsHistory: Bool = false, dstFilePath: String? = nil, concurrencyLimit: Int? = 1, disableCombineDefaultValues: Bool = false, errorHandler: (Error) -> Void = { _ in }, file: StaticString = #filePath, line: UInt = #line) {
         let dstFilePath = dstFilePath ?? defaultDstFilePath
         var mockList: [String]?
         if let mock = mockContent {
@@ -76,13 +76,13 @@ class MockoloTestCase: XCTestCase {
             mockList?.append(mock)
         }
         XCTAssertThrowsError(
-            try verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, useMockObservable: useMockObservable, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues),
+            try verify(srcContents: [srcContent], mockContents: mockList, dstContent: dstContent, header: header, declType: declType, useTemplateFunc: useTemplateFunc, testableImports: testableImports, allowSetCallCount: allowSetCallCount, mockFinal: mockFinal, enableFuncArgsHistory: enableFuncArgsHistory, dstFilePath: dstFilePath, concurrencyLimit: concurrencyLimit, disableCombineDefaultValues: disableCombineDefaultValues, file: file, line: line),
             "No error was thrown",
             errorHandler
         )
     }
 
-    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: FindTargetDeclType, useTemplateFunc: Bool, useMockObservable: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, dstFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool) throws {
+    func verify(srcContents: [String], mockContents: [String]?, dstContent: String, header: String, declType: FindTargetDeclType, useTemplateFunc: Bool, testableImports: [String] = [], allowSetCallCount: Bool, mockFinal: Bool, enableFuncArgsHistory: Bool, dstFilePath: String, concurrencyLimit: Int?, disableCombineDefaultValues: Bool, file: StaticString = #filePath, line: UInt = #line) throws {
         var index = 0
         srcFilePathsCount = srcContents.count
         mockFilePathsCount = mockContents?.count ?? 0
@@ -91,7 +91,7 @@ class MockoloTestCase: XCTestCase {
             if index < srcContents.count {
                 let srcCreated = FileManager.default.createFile(atPath: srcFilePaths[index], contents: src.data(using: .utf8), attributes: nil)
                 index += 1
-                XCTAssert(srcCreated)
+                XCTAssert(srcCreated, file: file, line: line)
             }
         }
 
@@ -108,7 +108,7 @@ class MockoloTestCase: XCTestCase {
                 \(macroEnd)
                 """
                 let mockCreated = FileManager.default.createFile(atPath: mockFilePaths[index], contents: formattedMockContent.data(using: .utf8), attributes: nil)
-                XCTAssert(mockCreated)
+                XCTAssert(mockCreated, file: file, line: line)
             }
         }
 
@@ -134,11 +134,47 @@ class MockoloTestCase: XCTestCase {
                      concurrencyLimit: concurrencyLimit)
         let output = (try? String(contentsOf: URL(fileURLWithPath: self.defaultDstFilePath), encoding: .utf8)) ?? ""
         let outputContents = output.components(separatedBy:  .newlines).filter { !$0.isEmpty && !$0.allSatisfy(\.isWhitespace) }
-        let fixtureContents = dstContent.components(separatedBy: .newlines).filter { !$0.isEmpty && !$0.allSatisfy(\.isWhitespace) }
+        let fixtureContents = """
+        \(headerStr)
+        \(macroStart)
+        \(dstContent)
+        \(macroEnd)
+        """.components(separatedBy: .newlines).filter { !$0.isEmpty && !$0.allSatisfy(\.isWhitespace) }
         if fixtureContents.isEmpty {
-            throw XCTSkip("empty fixture")
+            throw XCTSkip("empty fixture", file: file, line: line)
         }
-        XCTAssert(outputContents.contains(subArray: fixtureContents), "output:\n" + output)
+
+        let diff = lightDiff(old: outputContents, new: fixtureContents)
+        if !diff.isEmpty {
+            print("output:\n\(output)")
+            XCTFail("diff:\n" + "\(diff.joined(separator: "\n"))", file: file, line: line)
+        }
+    }
+}
+
+func lightDiff(old: [String], new: [String]) -> [String] {
+    return new.difference(from: old)
+        .sorted { l, r in
+            return l.offset < r.offset
+        }
+        .map { change in
+            switch change {
+            case .remove(_, let element, _):
+                return "- \(element)"
+            case .insert(_, let element, _):
+                return "+ \(element)"
+            }
+        }
+}
+
+extension CollectionDifference.Change {
+    var offset: Int {
+        switch self {
+        case .insert(let offset, _, _):
+            return offset
+        case .remove(let offset, _, _):
+            return offset
+        }
     }
 }
 

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -329,23 +329,22 @@ import MockoloFramework
     }
 
     @Fixture enum expected {
-//        class NonSimpleFuncsMock: NonSimpleFuncs {
-//            init() { }
-//
-//
-//            private(set) var barCallCount = 0
-//            var barHandler: ((String, Int..., [Double]) -> Float?)?
-//            func bar(_ arg: String, x: Int..., y: [Double]) -> Float? {
-//                barCallCount += 1
-//                if let barHandler = barHandler {
-//                    return barHandler(arg, x, y)
-//                }
-//                return nil
-//            }
-//        }
+        class NonSimpleFuncsMock: NonSimpleFuncs {
+            init() { }
+
+
+            private(set) var barCallCount = 0
+            var barHandler: ((String, [Int], [Double]) -> Float?)?
+            func bar(_ arg: String, x: Int..., y: [Double]) -> Float? {
+                barCallCount += 1
+                if let barHandler = barHandler {
+                    return barHandler(arg, x, y)
+                }
+                return nil
+            }
+        }
     }
 }
-
 
 @Fixture enum autoclosureArgFunc {
     /// @mockable
@@ -371,40 +370,35 @@ import MockoloFramework
     }
 }
 
-@Fixture enum closureArgFunc {
+#if compiler(>=6.0)
+@Fixture enum rethrowsFunc {
     /// @mockable
-    protocol NonSimpleFuncs {
-        func cat<T>(named arg: String, tags: [String: String]?, closure: () throws -> T) rethrows -> T
-        func more<T>(named arg: String, tags: [String: String]?, closure: (T) throws -> ()) rethrows -> T
+    protocol RethrowsFuncs {
+        func cat(closure: () throws -> Void) rethrows
     }
 
     @Fixture enum expected {
-//        class NonSimpleFuncsMock: NonSimpleFuncs {
-//            init() { }
-//            
-//            
-//            private(set) var catCallCount = 0
-//            var catHandler: ((String, [String: String]?, () throws -> Any) throws -> Any)?
-//            func cat<T>(named arg: String, tags: [String: String]?, closure: () throws -> T) rethrows -> T {
-//                catCallCount += 1
-//                if let catHandler = catHandler {
-//                    return try catHandler(arg, tags, closure) as! T
-//                }
-//                fatalError("catHandler returns can't have a default value thus its handler must be set")
-//            }
-//            
-//            private(set) var moreCallCount = 0
-//            var moreHandler: ((String, [String: String]?, (Any) throws -> ()) throws -> Any)?
-//            func more<T>(named arg: String, tags: [String: String]?, closure: (T) throws -> ()) rethrows -> T {
-//                moreCallCount += 1
-//                if let moreHandler = moreHandler {
-//                    return try moreHandler(arg, tags, closure) as! T
-//                }
-//                fatalError("moreHandler returns can't have a default value thus its handler must be set")
-//            }
-//        }
+        class RethrowsFuncsMock: RethrowsFuncs {
+            init() { }
+
+
+            private(set) var catCallCount = 0
+            var catHandler: ((() throws(any Error) -> Any) throws(any Error) -> Void)?
+            func cat<Failure: Error>(closure: () throws(Failure) -> Void) throws(Failure) {
+                catCallCount += 1
+                if let catHandler = catHandler {
+                    do {
+                        try catHandler(closure)
+                    } catch {
+                        throw error as! Failure
+                    }
+                }
+                fatalError("catHandler returns can't have a default value thus its handler must be set")
+            }
+        }
     }
 }
+#endif
 
 @Fixture enum forArgClosureFunc {
     /// @mockable

--- a/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
@@ -9,20 +9,22 @@ class BasicFuncTests: MockoloTestCase {
                dstContent: subscripts.expected._source)
     }
     
-    func testVariadicFuncs() {
-        verify(srcContent: variadicFunc._source,
-               dstContent: variadicFunc.expected._source)
-    }
+//    func testVariadicFuncs() {
+//        verify(srcContent: variadicFunc._source,
+//               dstContent: variadicFunc.expected._source)
+//    }
 
     func testAutoclosureArgFuncs() {
         verify(srcContent: autoclosureArgFunc._source,
                dstContent: autoclosureArgFunc.expected._source)
     }
 
-    func testClosureArgFuncs() {
-        verify(srcContent: closureArgFunc._source,
-               dstContent: closureArgFunc.expected._source)
-    }
+#if compiler(>=6.0)
+//    func testRethrowsFunc() {
+//        verify(srcContent: rethrowsFunc._source,
+//               dstContent: rethrowsFunc.expected._source)
+//    }
+#endif
 
     func testForArgFuncs() {
         verify(srcContent: forArgClosureFunc._source,
@@ -33,7 +35,6 @@ class BasicFuncTests: MockoloTestCase {
         verify(srcContent: returnSelfFunc._source,
                dstContent: returnSelfFunc.expected._source)
     }
-    
     
     func testSimpleFuncs() {
         verify(srcContent: simpleFuncs._source,

--- a/Tests/TestPerformance/PerformanceTests.swift
+++ b/Tests/TestPerformance/PerformanceTests.swift
@@ -15,11 +15,11 @@ class PerformanceTests: MockoloTestCase {
             for _ in 0..<5 {
                 invoke(BasicFuncTests.testInoutParams, name: "testInoutParams")
                 invoke(BasicFuncTests.testSubscripts, name: "testSubscripts")
-                invoke(BasicFuncTests.testVariadicFuncs, name: "testVariadicFuncs")
                 invoke(BasicFuncTests.testAutoclosureArgFuncs, name: "testAutoclosureArgFuncs")
-                invoke(BasicFuncTests.testClosureArgFuncs, name: "testClosureArgFuncs")
                 invoke(BasicFuncTests.testForArgFuncs, name: "testForArgFuncs")
                 invoke(BasicFuncTests.testReturnSelfFunc, name: "testReturnSelfFunc")
+                invoke(BasicFuncTests.testSimpleFuncs, name: "testReturnSelfFunc")
+                invoke(BasicFuncTests.testSimpleFuncsAllowCallCount, name: "testSimpleFuncsAllowCallCount")
 
                 invoke(OverloadTests.testOverloadPartialInParentAndChild, name: "testOverloadPartialInParentAndChild")
                 invoke(OverloadTests.testOverloadSameSigInMultiParents, name: "testOverloadSameSigInMultiParents")

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -7,10 +7,7 @@ import MockoloFramework
         func update(arg0: some Sendable, arg1: AnyObject) async throws
     }
 
-    @Fixture(
-        imports: ["Foundation"],
-        includesConcurrencyHelpers: true
-    )
+    @Fixture(includesConcurrencyHelpers: true)
     enum expected {
         public final class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
             public init() { }
@@ -75,10 +72,7 @@ import MockoloFramework
         }
     }
 
-    @Fixture(
-        imports: ["Foundation"],
-        includesConcurrencyHelpers: true
-    )
+    @Fixture(includesConcurrencyHelpers: true)
     enum expected {
         public final class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {
             public override init() { }
@@ -115,10 +109,7 @@ import MockoloFramework
     public protocol ConfirmedSendableProtocol: SendableSendable {
     }
 
-    @Fixture(
-        imports: ["Foundation"],
-        includesConcurrencyHelpers: true
-    )
+    @Fixture(includesConcurrencyHelpers: true)
     enum expected {
         public final class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
             public init() { }

--- a/Tests/TestSendable/FixtureSendable.swift
+++ b/Tests/TestSendable/FixtureSendable.swift
@@ -7,7 +7,11 @@ import MockoloFramework
         func update(arg0: some Sendable, arg1: AnyObject) async throws
     }
 
-    @Fixture enum expected {
+    @Fixture(
+        imports: ["Foundation"],
+        includesConcurrencyHelpers: true
+    )
+    enum expected {
         public final class SendableProtocolMock: SendableProtocol, @unchecked Sendable {
             public init() { }
 
@@ -71,7 +75,11 @@ import MockoloFramework
         }
     }
 
-    @Fixture enum expected {
+    @Fixture(
+        imports: ["Foundation"],
+        includesConcurrencyHelpers: true
+    )
+    enum expected {
         public final class UncheckedSendableClassMock: UncheckedSendableClass, @unchecked Sendable {
             public override init() { }
 
@@ -107,7 +115,11 @@ import MockoloFramework
     public protocol ConfirmedSendableProtocol: SendableSendable {
     }
 
-    @Fixture enum expected {
+    @Fixture(
+        imports: ["Foundation"],
+        includesConcurrencyHelpers: true
+    )
+    enum expected {
         public final class ConfirmedSendableProtocolMock: ConfirmedSendableProtocol, @unchecked Sendable {
             public init() { }
 

--- a/Tests/TestSupportMacros.swift
+++ b/Tests/TestSupportMacros.swift
@@ -1,5 +1,6 @@
 @attached(member, names: named(_source))
 macro Fixture(
     imports: [String]? = nil,
+    testableImports: [String]? = nil,
     includesConcurrencyHelpers: Bool = false
 ) = #externalMacro(module: "MockoloTestSupportMacros", type: "Fixture")

--- a/Tests/TestSupportMacros.swift
+++ b/Tests/TestSupportMacros.swift
@@ -1,2 +1,5 @@
 @attached(member, names: named(_source))
-macro Fixture() = #externalMacro(module: "MockoloTestSupportMacros", type: "Fixture")
+macro Fixture(
+    imports: [String]? = nil,
+    includesConcurrencyHelpers: Bool = false
+) = #externalMacro(module: "MockoloTestSupportMacros", type: "Fixture")

--- a/Tests/TestTestableImports/FixtureTestableImportStatements.swift
+++ b/Tests/TestTestableImports/FixtureTestableImportStatements.swift
@@ -1,54 +1,54 @@
 import MockoloFramework
 
-let testableImports = """
-\(String.headerDoc)
-import Foundation
-
-/// @mockable
-protocol SimpleVar {
-    var name: Int { get set }
-}
-"""
-
-let testableImportsMock = """
-import Foundation
-@testable import SomeImport1
-@testable import SomeImport2
-
-class SimpleVarMock: SimpleVar {
-    init() { }
-    init(name: Int = 0) {
-        self.name = name
+@Fixture(
+    imports: ["Foundation"]
+)
+enum testableImports {
+    /// @mockable
+    protocol SimpleVar {
+        var name: Int { get set }
     }
 
-
-    private(set) var nameSetCallCount = 0
-    var name: Int = 0 { didSet { nameSetCallCount += 1 } }
+    @Fixture(
+        imports: ["Foundation"],
+        testableImports: ["SomeImport1", "SomeImport2"]
+    )
+    enum expected {
+        class SimpleVarMock: SimpleVar {
+            init() { }
+            init(name: Int = 0) {
+                self.name = name
+            }
+            
+            
+            private(set) var nameSetCallCount = 0
+            var name: Int = 0 { didSet { nameSetCallCount += 1 } }
+        }
+    }
 }
-"""
 
-let testableImportsWithOverlap = """
-\(String.headerDoc)
-import Foundation
-import SomeImport1
-
-/// @mockable
-protocol SimpleVar {
-    var name: Int { get set }
-}
-"""
-
-let testableImportsWithOverlapMock = """
-import Foundation
-@testable import SomeImport1
-
-class SimpleVarMock: SimpleVar {
-    init() { }
-    init(name: Int = 0) {
-        self.name = name
+@Fixture(
+    imports: ["Foundation", "SomeImport1"]
+)
+enum testableImportsWithOverlap {
+    /// @mockable
+    protocol SimpleVar {
+        var name: Int { get set }
     }
 
-    private(set) var nameSetCallCount = 0
-    var name: Int = 0 { didSet { nameSetCallCount += 1 } }
+    @Fixture(
+        imports: ["Foundation"],
+        testableImports: ["SomeImport1"]
+    )
+    enum expected {
+        class SimpleVarMock: SimpleVar {
+            init() { }
+            init(name: Int = 0) {
+                self.name = name
+            }
+
+            private(set) var nameSetCallCount = 0
+            var name: Int = 0 { didSet { nameSetCallCount += 1 } }
+        }
+    }
 }
-"""

--- a/Tests/TestTestableImports/TestableImportStatementsTests.swift
+++ b/Tests/TestTestableImports/TestableImportStatementsTests.swift
@@ -1,16 +1,13 @@
-import Foundation
-
 class TestableImportStatementsTests: MockoloTestCase {
-    
     func testTestableImportStatements() {
-        verify(srcContent: testableImports,
-               dstContent: testableImportsMock,
+        verify(srcContent: testableImports._source,
+               dstContent: testableImports.expected._source,
                testableImports: ["SomeImport1", "SomeImport2"])
     }
 
     func testTestableImportStatementsWithOverlap() {
-        verify(srcContent: testableImportsWithOverlap,
-               dstContent: testableImportsWithOverlapMock,
+        verify(srcContent: testableImportsWithOverlap._source,
+               dstContent: testableImportsWithOverlap.expected._source,
                testableImports: ["SomeImport1"])
     }
 }


### PR DESCRIPTION
## Issue

- https://github.com/uber/mockolo/issues/295
    - Code that is not included in the Fixture is not being validated.
    - When checking for an exact match with the Fixture, it is necessary to include ConcurrencyHelper in the Fixture each time.
- Other test improvements.

## Solution
- Modify the `@Fixture` macro to make it easy to include ConcurrencyHelper.

## Changes
- Add an option to the `@Fixture` macro so that ConcurrencyHelper can be included.
- Also allow import statements to be specified.
- Display diffs for parts that differ from the Fixture.
- Visualize failed test cases.
- Rewrite `TestableImportStatementsTests` using the `@Fixture` macro.