### PR TITLE
Update CI Configuration

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -14,11 +14,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [macos-latest, ubuntu-latest]
-        swift: ["5.10", "6.0"]
+        swift: ["5.10", "6.0", "6.1"]
     steps:
-      - uses: swift-actions/setup-swift@v2
+      - if: startsWith(matrix.destination.name, 'linux')
+        uses: vapor/swiftly-action@v0.2
+        with:
+          toolchain: ${{ matrix.swift }}
+      - if: startsWith(matrix.destination.name, 'macos')
+        uses: swift-actions/setup-swift@v2
         with:
           swift-version: ${{ matrix.swift }}
+
       - name: Checkout
         uses: actions/checkout@v4
       - name: Build and Test

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,7 +98,7 @@ jobs:
 
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
-    needs: [check-portability, check-portability-with-qemu, make-artifact-bundle]
+    needs: [check-portability, make-artifact-bundle]
     runs-on: ubuntu-latest
     steps:
     - uses: actions/download-artifact@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -17,8 +17,8 @@ jobs:
     strategy:
       matrix:
         destination:
-          - { name: "linux-aarch64", os: ubuntu-22.04 }
-          - { name: "linux-x86_64", os: ubuntu-22.04 }
+          - { name: "ubuntu-aarch64", os: ubuntu-22.04-arm }
+          - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
           - { name: "macos-universal", os: macos-15 }
     steps:
     - if: startsWith(matrix.destination.name, 'linux')
@@ -48,10 +48,10 @@ jobs:
       fail-fast: false
       matrix:
         destination:
-          - { name: "linux-x86_64", os: ubuntu-24.04 }
-          - { name: "linux-x86_64", os: ubuntu-22.04 }
-          - { name: "linux-aarch64", os: ubuntu-24.04-arm }
-          - { name: "linux-aarch64", os: ubuntu-22.04-arm }
+          - { name: "ubuntu-x86_64", os: ubuntu-24.04 }
+          - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
+          - { name: "ubuntu-aarch64", os: ubuntu-24.04-arm }
+          - { name: "ubuntu-aarch64", os: ubuntu-22.04-arm }
           - { name: "macos-universal", os: macos-15 }
           - { name: "macos-universal", os: macos-14 }
           - { name: "macos-universal", os: macos-13 }
@@ -112,7 +112,7 @@ jobs:
 
           ## For Build Tools Plugin (artifactbundle)
 
-          - full version (linux and macos)
+          - full version (ubuntu and macos)
 
           ```swift
           .binaryTarget(
@@ -133,8 +133,8 @@ jobs:
           ```
         append_body: true
         files: |
-          mockolo.linux-x86_64.tar.gz
-          mockolo.linux-aarch64.tar.gz
+          mockolo.ubuntu-x86_64.tar.gz
+          mockolo.ubuntu-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
           mockolo.artifactbundle.zip
           mockolo-macos.artifactbundle.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
         destination:
           - { name: "linux-aarch64", os: ubuntu-22.04 }
           - { name: "linux-x86_64", os: ubuntu-22.04 }
-          - { name: "macos-universal", os: macos-latest }
+          - { name: "macos-universal", os: macos-15 }
     steps:
     - if: startsWith(matrix.destination.name, 'linux')
       uses: vapor/swiftly-action@v0.2

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -64,7 +64,6 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       checksum: ${{ steps.checksum.outputs.checksum }}
-      checksum-macos: ${{ steps.checksum-macos.outputs.checksum }}
     steps:
       - uses: actions/checkout@v4
       - name: Download all artifacts
@@ -78,18 +77,10 @@ jobs:
         with:
           name: mockolo.artifactbundle.zip
           path: mockolo.artifactbundle.zip
-      - name: Upload artifact bundle maocs
-        uses: actions/upload-artifact@v4
-        with:
-          name: mockolo-macos.artifactbundle.zip
-          path: mockolo-macos.artifactbundle.zip
-
+      
       - name: Compute checksum
         id: checksum
         run: echo "checksum=$(swift package compute-checksum mockolo.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
-      - name: Compute checksum macos
-        id: checksum-macos
-        run: echo "checksum=$(swift package compute-checksum mockolo-macos.artifactbundle.zip)" >> "$GITHUB_OUTPUT"
 
   deploy-binary:
     if: ${{ github.event_name == 'release' }}
@@ -107,8 +98,6 @@ jobs:
 
           ## For Build Tools Plugin (artifactbundle)
 
-          - full version (ubuntu and macos)
-
           ```swift
           .binaryTarget(
               name: "mockolo",
@@ -117,19 +106,9 @@ jobs:
           ),
           ```
 
-          - lightweight version (macos only)
-
-          ```swift
-          .binaryTarget(
-              name: "mockolo",
-              url: "https://github.com/${{ github.repository }}/releases/download/${{ github.event.release.tag_name }}/mockolo-macos.artifactbundle.zip",
-              checksum: "${{ needs.make-artifact-bundle.outputs.checksum-macos }}"
-          ),
-          ```
         append_body: true
         files: |
           mockolo.ubuntu-x86_64.tar.gz
           mockolo.ubuntu-aarch64.tar.gz
           mockolo.macos-universal.tar.gz
           mockolo.artifactbundle.zip
-          mockolo-macos.artifactbundle.zip

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,8 +7,6 @@ on:
 
 env:
   SWIFT_VERSION: "6.1.0"
-  SWIFT_SDK_URL: https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
-  SWIFT_SDK_CHECKSUM: 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
 
 jobs:
   build:
@@ -25,9 +23,6 @@ jobs:
       uses: vapor/swiftly-action@v0.2
       with:
         toolchain: ${{ env.SWIFT_VERSION }}
-    - if: startsWith(matrix.destination.name, 'linux')
-      name: Install swift sdk
-      run: swift sdk install ${{ env.SWIFT_SDK_URL }} --checksum ${{ env.SWIFT_SDK_CHECKSUM }}
     - if: startsWith(matrix.destination.name, 'macos')
       run: sudo xcode-select -s /Applications/Xcode_16.3.app
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,9 +6,9 @@ on:
     types: [published]
 
 env:
-  SWIFT_VERSION: "6.0.3"
-  SWIFT_SDK_URL: https://download.swift.org/swift-6.0.3-release/static-sdk/swift-6.0.3-RELEASE/swift-6.0.3-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
-  SWIFT_SDK_CHECKSUM: 67f765e0030e661a7450f7e4877cfe008db4f57f177d5a08a6e26fd661cdd0bd
+  SWIFT_VERSION: "6.1.0"
+  SWIFT_SDK_URL: https://download.swift.org/swift-6.1-release/static-sdk/swift-6.1-RELEASE/swift-6.1-RELEASE_static-linux-0.0.1.artifactbundle.tar.gz
+  SWIFT_SDK_CHECKSUM: 111c6f7d280a651208b8c74c0521dd99365d785c1976a6e23162f55f65379ac6
 
 jobs:
   build:
@@ -22,14 +22,14 @@ jobs:
           - { name: "macos-universal", os: macos-latest }
     steps:
     - if: startsWith(matrix.destination.name, 'linux')
-      uses: vapor/swiftly-action@v0.1
+      uses: vapor/swiftly-action@v0.2
       with:
         toolchain: ${{ env.SWIFT_VERSION }}
     - if: startsWith(matrix.destination.name, 'linux')
       name: Install swift sdk
       run: swift sdk install ${{ env.SWIFT_SDK_URL }} --checksum ${{ env.SWIFT_SDK_CHECKSUM }}
     - if: startsWith(matrix.destination.name, 'macos')
-      run: sudo xcode-select -s /Applications/Xcode_16.2.app
+      run: sudo xcode-select -s /Applications/Xcode_16.3.app
 
     - uses: actions/checkout@v4
     - name: Create the binary
@@ -50,6 +50,9 @@ jobs:
         destination:
           - { name: "linux-x86_64", os: ubuntu-24.04 }
           - { name: "linux-x86_64", os: ubuntu-22.04 }
+          - { name: "linux-aarch64", os: ubuntu-24.04-arm }
+          - { name: "linux-aarch64", os: ubuntu-22.04-arm }
+          - { name: "macos-universal", os: macos-15 }
           - { name: "macos-universal", os: macos-14 }
           - { name: "macos-universal", os: macos-13 }
     steps:
@@ -60,32 +63,6 @@ jobs:
       run: tar -xvf mockolo.${{ matrix.destination.name }}.tar.gz
     - name: Run the binary
       run: ./mockolo --version
-
-  check-portability-with-qemu:
-    needs: build
-    name: TestRun on ${{ matrix.destination.tag }}
-    runs-on: ubuntu-latest
-    strategy:
-      fail-fast: false
-      matrix:
-        destination:
-          - { name: "linux-aarch64", tag: "ubuntu:24.04" }
-          - { name: "linux-aarch64", tag: "ubuntu:22.04" }
-    steps:
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
-
-    - uses: actions/download-artifact@v4
-      with:
-        name: mockolo.${{ matrix.destination.name }}.tar.gz
-    - name: Unpack the binary
-      run: tar -xvf mockolo.${{ matrix.destination.name }}.tar.gz
-    - name: Run the binary
-      run: |
-        docker run --platform linux/arm64 --rm -v ${{ github.workspace }}:/work -w /work ${{ matrix.destination.tag }} \
-          ./mockolo --version
 
   make-artifact-bundle:
     needs: [build]

--- a/bundle/info.json
+++ b/bundle/info.json
@@ -10,11 +10,11 @@
                     "supportedTriples": ["x86_64-apple-macosx", "arm64-apple-macosx"]
                 },
                 {
-                    "path": "mockolo/linux/x86_64-unknown-linux-gnu/mockolo",
+                    "path": "mockolo/ubuntu/x86_64-unknown-linux-gnu/mockolo",
                     "supportedTriples": ["x86_64-unknown-linux-gnu"]
                 },
                 {
-                    "path": "mockolo/linux/aarch64-unknown-linux-gnu/mockolo",
+                    "path": "mockolo/ubuntu/aarch64-unknown-linux-gnu/mockolo",
                     "supportedTriples": ["aarch64-unknown-linux-gnu"]
                 }
             ]

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -14,18 +14,18 @@ fi
 
 # Archive universal artifacts
 mkdir -p mockolo.artifactbundle/mockolo/macos
-mkdir -p mockolo.artifactbundle/mockolo/linux/x86_64-unknown-linux-gnu
-mkdir -p mockolo.artifactbundle/mockolo/linux/aarch64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu
+mkdir -p mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu
 
 tar -xzf mockolo.macos-universal.tar.gz -C mockolo.artifactbundle/mockolo/macos/
-tar -xzf mockolo.linux-x86_64.tar.gz -C mockolo.artifactbundle/mockolo/linux/x86_64-unknown-linux-gnu/
-tar -xzf mockolo.linux-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/linux/aarch64-unknown-linux-gnu/
+tar -xzf mockolo.ubuntu-x86_64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/x86_64-unknown-linux-gnu/
+tar -xzf mockolo.ubuntu-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/aarch64-unknown-linux-gnu/
 
 sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > mockolo.artifactbundle/info.json
 
 zip -r ./mockolo.artifactbundle.zip ./mockolo.artifactbundle
 
-# Archive macOS artifacts
+# Archive macOS only artifacts
 mkdir -p mockolo-macos.artifactbundle/mockolo/macos
 
 tar -xzf mockolo.macos-universal.tar.gz -C mockolo-macos.artifactbundle/mockolo/macos/

--- a/bundle/make_artifactbundle.sh
+++ b/bundle/make_artifactbundle.sh
@@ -24,12 +24,3 @@ tar -xzf mockolo.ubuntu-aarch64.tar.gz -C mockolo.artifactbundle/mockolo/ubuntu/
 sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info.json > mockolo.artifactbundle/info.json
 
 zip -r ./mockolo.artifactbundle.zip ./mockolo.artifactbundle
-
-# Archive macOS only artifacts
-mkdir -p mockolo-macos.artifactbundle/mockolo/macos
-
-tar -xzf mockolo.macos-universal.tar.gz -C mockolo-macos.artifactbundle/mockolo/macos/
-
-sed 's/__VERSION__/'$VERSION'/g' $(dirname $0)/info-macos.json > mockolo-macos.artifactbundle/info.json
-
-zip -r ./mockolo-macos.artifactbundle.zip ./mockolo-macos.artifactbundle

--- a/install-script.sh
+++ b/install-script.sh
@@ -65,7 +65,7 @@ echo "OUTPUT FILE = ${OUTFILE}"
 cd "$SRCDIR"
 rm -rf .build
 case $(uname -s) in
-    Linux*)     swift build -c release --swift-sdk $(uname -p)-swift-linux-musl
+    Linux*)     swift build -c release
                 cd .build/release;;
     Darwin*)    swift build -c release --arch arm64 --arch x86_64
                 cd .build/apple/Products/Release;;


### PR DESCRIPTION
Switch release build to use Swift 6.1 and update outdated dependencies.

I have decided to stop using the Swift SDK for the following reasons:

- The static Linux SDK significantly increases the size of the output binary.
- Distributing the artifact bundle to every Linux environment is not a priority. Previously (before [#265](https://github.com/uber/mockolo/pull/265)), the artifact was only shipped to Ubuntu, and the main reason for switching to the Swift SDK was to improve build times.
    - Ubuntu will continue to be the primary supported Linux distribution. Support for other distributions can be added upon request.
- We can now utilize ARM Linux machines provided by GitHub, making it straightforward and efficient to build ARM binaries.