### PR TITLE
Fix matrix destination name in release.yml

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -19,7 +19,7 @@ jobs:
           - { name: "ubuntu-x86_64", os: ubuntu-22.04 }
           - { name: "macos-universal", os: macos-15 }
     steps:
-    - if: startsWith(matrix.destination.name, 'linux')
+    - if: startsWith(matrix.destination.name, 'ubuntu')
       uses: vapor/swiftly-action@v0.2
       with:
         toolchain: ${{ env.SWIFT_VERSION }}


### PR DESCRIPTION
It turns out this wasn’t actually an issue, since Swift 6.1 appears to be pre-installed on the [Ubuntu 22.04 image](https://github.com/actions/runner-images/blob/main/images/ubuntu/Ubuntu2204-Readme.md).