### PR TITLE
Place member attributes on methods and variables instead of class

### DIFF
--- a/Sources/MockoloFramework/Models/MethodModel.swift
+++ b/Sources/MockoloFramework/Models/MethodModel.swift
@@ -32,6 +32,7 @@ final class MethodModel: Model {
     let params: [ParamModel]
     let processed: Bool
     let modelDescription: String?
+    let attributes: String
     let isStatic: Bool
     let isAsync: Bool
     let throwing: ThrowingKind
@@ -161,6 +162,7 @@ final class MethodModel: Model {
          length: Int64,
          funcsWithArgsHistory: [String],
          customModifiers: [String: Modifier],
+         attributes: String,
          modelDescription: String?,
          processed: Bool) {
         self.name = name.trimmingCharacters(in: .whitespaces)
@@ -177,6 +179,7 @@ final class MethodModel: Model {
         self.processed = processed
         self.funcsWithArgsHistory = funcsWithArgsHistory
         self.customModifiers = customModifiers
+        self.attributes = attributes
         self.modelDescription = modelDescription
         self.accessLevel = acl
     }

--- a/Sources/MockoloFramework/Models/VariableModel.swift
+++ b/Sources/MockoloFramework/Models/VariableModel.swift
@@ -54,6 +54,7 @@ final class VariableModel: Model {
          customModifiers: [String: Modifier]?,
          modelDescription: String?,
          combineType: CombineType?,
+         attributes: [String]?,
          processed: Bool) {
         self.name = name
         self.type = type
@@ -65,7 +66,7 @@ final class VariableModel: Model {
         self.rxTypes = rxTypes
         self.customModifiers = customModifiers
         self.accessLevel = acl ?? ""
-        self.attributes = nil
+        self.attributes = attributes
         self.modelDescription = modelDescription
         self.combineType = combineType
     }

--- a/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
+++ b/Sources/MockoloFramework/Parsers/SwiftSyntaxExtensions.swift
@@ -222,14 +222,8 @@ extension MemberBlockItemListSyntax {
             if let (item, attr, initFlag) = m.transformToModel(with: encloserAcl, declKind: declKind, metadata: metadata, processed: processed) {
                 memberList.append(item)
                 if let attrDesc = attr {
-                    let shouldFilterMemberAttributes = item is MethodModel || item is VariableModel
-                    
-                    if shouldFilterMemberAttributes {
-                        let memberAttributes = ["@available", "@objc", "@discardableResult"]
-                        if !memberAttributes.contains(where: { attrDesc.contains($0) }) {
-                            attributeList.append(attrDesc)
-                        }
-                    } else {
+                    let isMemberAttribute = item is MethodModel || item is VariableModel
+                    if !isMemberAttribute {
                         attributeList.append(attrDesc)
                     }
                 }

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -132,15 +132,18 @@ extension MethodModel {
             )
             let genericWhereStr = model.genericWhereClause.map { "\($0) " } ?? ""
             
-            let methodAttributes = model.attributes.components(separatedBy: "\n")
-                .filter { attr in
-                    attr.contains("@available")
+            var availableStr = ""
+            var inlineStr = ""
+            for attr in model.attributes.components(separatedBy: "\n") where !attr.isEmpty {
+                if attr.contains("@available") {
+                    availableStr += "\(1.tab)\(attr)\n"
+                } else {
+                    inlineStr += "\(attr) "
                 }
-                .joined(separator: "\n")
-            let attributesStr = methodAttributes.isEmpty ? "" : "\(1.tab)\(methodAttributes)\n"
+            }
 
             let functionDecl = """
-            \(attributesStr)\(1.tab)\(declModifiers)\(overrideStr)\(modifierTypeStr)\(keyword)\(model.name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnClause)\(genericWhereStr){
+            \(availableStr)\(1.tab)\(inlineStr)\(declModifiers)\(overrideStr)\(modifierTypeStr)\(keyword)\(model.name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnClause)\(genericWhereStr){
             \(wrapped)
             \(1.tab)}
             """

--- a/Sources/MockoloFramework/Templates/MethodTemplate.swift
+++ b/Sources/MockoloFramework/Templates/MethodTemplate.swift
@@ -131,9 +131,16 @@ extension MethodModel {
                 throwing: model.throwing
             )
             let genericWhereStr = model.genericWhereClause.map { "\($0) " } ?? ""
+            
+            let methodAttributes = model.attributes.components(separatedBy: "\n")
+                .filter { attr in
+                    attr.contains("@available")
+                }
+                .joined(separator: "\n")
+            let attributesStr = methodAttributes.isEmpty ? "" : "\(1.tab)\(methodAttributes)\n"
 
             let functionDecl = """
-            \(1.tab)\(declModifiers)\(overrideStr)\(modifierTypeStr)\(keyword)\(model.name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnClause)\(genericWhereStr){
+            \(attributesStr)\(1.tab)\(declModifiers)\(overrideStr)\(modifierTypeStr)\(keyword)\(model.name)\(genericTypesStr)(\(paramDeclsStr)) \(suffixStr)\(returnClause)\(genericWhereStr){
             \(wrapped)
             \(1.tab)}
             """

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -56,6 +56,16 @@ extension VariableModel {
         }
 
         let staticSpace = isStatic ? "\(String.static) " : ""
+        
+        let availableAttr = (attributes ?? [])
+            .filter { $0.contains("@available") }
+            .joined(separator: "\n")
+        let availableStr = availableAttr.isEmpty ? "" : "\(1.tab)\(availableAttr)\n"
+        
+        let objcAttr = (attributes ?? [])
+            .filter { $0.contains("@objc") }
+            .joined(separator: " ")
+        let objcStr = objcAttr.isEmpty ? "" : "\(objcAttr) "
 
         switch storageKind {
         case .stored(let needSetCount):
@@ -88,7 +98,7 @@ extension VariableModel {
                 
                 \(setCallCountVarDecl)
                 \(1.tab)\(propertyWrapper)\(staticSpace)private var \(underlyingName): \(underlyingType)\(assignVal)\(accessorBlock)
-                \(1.tab)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
+                \(availableStr)\(1.tab)\(objcStr)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
                 \(2.tab)get { return \(underlyingName) }
                 \(2.tab)set { \(underlyingName) = newValue }
                 \(1.tab)}
@@ -97,7 +107,7 @@ extension VariableModel {
                 template = """
                 
                 \(setCallCountVarDecl)
-                \(1.tab)\(propertyWrapper)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName)\(assignVal)\(accessorBlock)
+                \(availableStr)\(1.tab)\(objcStr)\(propertyWrapper)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName)\(assignVal)\(accessorBlock)
                 """
             }
 

--- a/Sources/MockoloFramework/Templates/VariableTemplate.swift
+++ b/Sources/MockoloFramework/Templates/VariableTemplate.swift
@@ -57,15 +57,15 @@ extension VariableModel {
 
         let staticSpace = isStatic ? "\(String.static) " : ""
         
-        let availableAttr = (attributes ?? [])
-            .filter { $0.contains("@available") }
-            .joined(separator: "\n")
-        let availableStr = availableAttr.isEmpty ? "" : "\(1.tab)\(availableAttr)\n"
-        
-        let objcAttr = (attributes ?? [])
-            .filter { $0.contains("@objc") }
-            .joined(separator: " ")
-        let objcStr = objcAttr.isEmpty ? "" : "\(objcAttr) "
+        var availableStr = ""
+        var inlineStr = ""
+        for attr in (attributes ?? []) where !attr.isEmpty {
+            if attr.contains("@available") {
+                availableStr += "\(1.tab)\(attr)\n"
+            } else {
+                inlineStr += "\(attr) "
+            }
+        }
 
         switch storageKind {
         case .stored(let needSetCount):
@@ -98,7 +98,7 @@ extension VariableModel {
                 
                 \(setCallCountVarDecl)
                 \(1.tab)\(propertyWrapper)\(staticSpace)private var \(underlyingName): \(underlyingType)\(assignVal)\(accessorBlock)
-                \(availableStr)\(1.tab)\(objcStr)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
+                \(availableStr)\(1.tab)\(inlineStr)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName) {
                 \(2.tab)get { return \(underlyingName) }
                 \(2.tab)set { \(underlyingName) = newValue }
                 \(1.tab)}
@@ -107,7 +107,7 @@ extension VariableModel {
                 template = """
                 
                 \(setCallCountVarDecl)
-                \(availableStr)\(1.tab)\(objcStr)\(propertyWrapper)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName)\(assignVal)\(accessorBlock)
+                \(availableStr)\(1.tab)\(inlineStr)\(propertyWrapper)\(acl)\(staticSpace)\(overrideStr)\(modifierTypeStr)var \(name): \(type.typeName)\(assignVal)\(accessorBlock)
                 """
             }
 

--- a/Tests/TestEmojis/FixtureEmojis.swift
+++ b/Tests/TestEmojis/FixtureEmojis.swift
@@ -42,7 +42,6 @@ public class EmojiParentMock: EmojiParent {
 
 
 let emojiVarsMock = """
-@available(iOS 10.0, *)
 class EmojiVarsMock: EmojiVars {
     init() { }
     init(😂: Emoji) {
@@ -52,6 +51,7 @@ class EmojiVarsMock: EmojiVars {
 
     private(set) var 😂SetCallCount = 0
     private var _😂: Emoji! { didSet { 😂SetCallCount += 1 } }
+    @available(iOS 10.0, *)
     var 😂: Emoji {
         get { return _😂 }
         set { _😂 = newValue }
@@ -64,7 +64,6 @@ class EmojiVarsMock: EmojiVars {
 let emojiCombMock = """
 import Foundation
 
-@available(iOS 10.0, *)
 class EmojiVarsMock: EmojiVars {
     init() { }
     init(😂: Emoji, dict: Dictionary<String, Int> = Dictionary<String, Int>(), 👍: Emoji, 👌😳👍: Emoji) {
@@ -77,6 +76,7 @@ class EmojiVarsMock: EmojiVars {
 
     private(set) var 😂SetCallCount = 0
     private var _😂: Emoji! { didSet { 😂SetCallCount += 1 } }
+    @available(iOS 10.0, *)
     var 😂: Emoji {
         get { return _😂 }
         set { _😂 = newValue }

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -482,7 +482,7 @@ import MockoloFramework
             
             private(set) var returnSelfCallCount = 0
             var returnSelfHandler: (() -> NonSimpleFuncsMock)?
-            func returnSelf() -> Self {
+            @discardableResult func returnSelf() -> Self {
                 returnSelfCallCount += 1
                 if let returnSelfHandler = returnSelfHandler {
                     return returnSelfHandler() as! Self

--- a/Tests/TestInit/FixtureInit.swift
+++ b/Tests/TestInit/FixtureInit.swift
@@ -235,7 +235,7 @@ public class ForcastUpdatingMock: ForcastUpdating {
 
     public private(set) var enabledCallCount = 0
     public var enabledHandler: (() -> Bool)?
-    public func enabled() -> Bool {
+    @objc public func enabled() -> Bool {
         enabledCallCount += 1
         if let enabledHandler = enabledHandler {
             return enabledHandler()
@@ -245,7 +245,7 @@ public class ForcastUpdatingMock: ForcastUpdating {
 
     public private(set) var forcastLoaderCallCount = 0
     public var forcastLoaderHandler: (() -> ForcastLoading?)?
-    public func forcastLoader() -> ForcastLoading? {
+    @objc public func forcastLoader() -> ForcastLoading? {
         forcastLoaderCallCount += 1
         if let forcastLoaderHandler = forcastLoaderHandler {
             return forcastLoaderHandler()
@@ -255,7 +255,7 @@ public class ForcastUpdatingMock: ForcastUpdating {
 
     public private(set) var fetchInfoCallCount = 0
     public var fetchInfoHandler: ((URL, @escaping (String?, URL?) -> ()) -> ())?
-    public func fetchInfo(fromItmsURL itmsURL: URL, completionHandler: @escaping (String?, URL?) -> ()) {
+    @objc public func fetchInfo(fromItmsURL itmsURL: URL, completionHandler: @escaping (String?, URL?) -> ()) {
         fetchInfoCallCount += 1
         if let fetchInfoHandler = fetchInfoHandler {
             fetchInfoHandler(itmsURL, completionHandler)

--- a/Tests/TestMemberAttributes/FixtureMemberAttributes.swift
+++ b/Tests/TestMemberAttributes/FixtureMemberAttributes.swift
@@ -1,0 +1,72 @@
+import MockoloFramework
+
+let methodAndVariableAttributes = """
+/// @mockable
+protocol AttributeProtocol {
+    @available(*, deprecated, message: "Use newMethod instead")
+    func oldMethod()
+    
+    @available(iOS 10.0, *)
+    var availableProperty: String { get }
+    
+    @objc var objcProperty: Int { get }
+    
+    @objc func newMethod()
+    
+    @discardableResult
+    func method() -> Int
+    
+    var normalProperty: Bool { get }
+}
+"""
+
+let methodAndVariableAttributesMock = """
+class AttributeProtocolMock: AttributeProtocol {
+    init() { }
+    init(availableProperty: String = "", objcProperty: Int = 0, normalProperty: Bool = false) {
+        self.availableProperty = availableProperty
+        self.objcProperty = objcProperty
+        self.normalProperty = normalProperty
+    }
+
+
+    private(set) var oldMethodCallCount = 0
+    var oldMethodHandler: (() -> ())?
+    @available(*, deprecated, message: "Use newMethod instead")
+    func oldMethod() {
+        oldMethodCallCount += 1
+        if let oldMethodHandler = oldMethodHandler {
+            oldMethodHandler()
+        }
+        
+    }
+
+    @available(iOS 10.0, *)
+    var availableProperty: String = ""
+
+    @objc var objcProperty: Int = 0
+
+    private(set) var newMethodCallCount = 0
+    var newMethodHandler: (() -> ())?
+    func newMethod() {
+        newMethodCallCount += 1
+        if let newMethodHandler = newMethodHandler {
+            newMethodHandler()
+        }
+        
+    }
+
+    private(set) var methodCallCount = 0
+    var methodHandler: (() -> Int)?
+    func method() -> Int {
+        methodCallCount += 1
+        if let methodHandler = methodHandler {
+            return methodHandler()
+        }
+        return 0
+    }
+
+    var normalProperty: Bool = false
+}
+"""
+

--- a/Tests/TestMemberAttributes/FixtureMemberAttributes.swift
+++ b/Tests/TestMemberAttributes/FixtureMemberAttributes.swift
@@ -1,72 +1,55 @@
+import Foundation
 import MockoloFramework
 
-let methodAndVariableAttributes = """
-/// @mockable
-protocol AttributeProtocol {
-    @available(*, deprecated, message: "Use newMethod instead")
-    func oldMethod()
-    
-    @available(iOS 10.0, *)
-    var availableProperty: String { get }
-    
-    @objc var objcProperty: Int { get }
-    
-    @objc func newMethod()
-    
-    @discardableResult
-    func method() -> Int
-    
-    var normalProperty: Bool { get }
-}
-"""
-
-let methodAndVariableAttributesMock = """
-class AttributeProtocolMock: AttributeProtocol {
-    init() { }
-    init(availableProperty: String = "", objcProperty: Int = 0, normalProperty: Bool = false) {
-        self.availableProperty = availableProperty
-        self.objcProperty = objcProperty
-        self.normalProperty = normalProperty
-    }
-
-
-    private(set) var oldMethodCallCount = 0
-    var oldMethodHandler: (() -> ())?
-    @available(*, deprecated, message: "Use newMethod instead")
-    func oldMethod() {
-        oldMethodCallCount += 1
-        if let oldMethodHandler = oldMethodHandler {
-            oldMethodHandler()
-        }
+@Fixture enum memberAttributes {
+    /// @mockable
+    protocol AttributeProtocol {
+        @available(*, deprecated, message: "Use newMethod instead")
+        func oldMethod()
         
-    }
-
-    @available(iOS 10.0, *)
-    var availableProperty: String = ""
-
-    @objc var objcProperty: Int = 0
-
-    private(set) var newMethodCallCount = 0
-    var newMethodHandler: (() -> ())?
-    func newMethod() {
-        newMethodCallCount += 1
-        if let newMethodHandler = newMethodHandler {
-            newMethodHandler()
-        }
+        @available(iOS 10.0, *)
+        var availableProperty: String { get }
         
+        @discardableResult
+        func method() -> Int
+        
+        var normalProperty: Bool { get }
     }
 
-    private(set) var methodCallCount = 0
-    var methodHandler: (() -> Int)?
-    func method() -> Int {
-        methodCallCount += 1
-        if let methodHandler = methodHandler {
-            return methodHandler()
+    @Fixture enum expected {
+        class AttributeProtocolMock: AttributeProtocol {
+            init() { }
+            init(availableProperty: String = "", normalProperty: Bool = false) {
+                self.availableProperty = availableProperty
+                self.normalProperty = normalProperty
+            }
+
+
+            private(set) var oldMethodCallCount = 0
+            var oldMethodHandler: (() -> ())?
+            @available(*, deprecated, message: "Use newMethod instead")
+            func oldMethod() {
+                oldMethodCallCount += 1
+                if let oldMethodHandler = oldMethodHandler {
+                    oldMethodHandler()
+                }
+                
+            }
+
+            @available(iOS 10.0, *)
+            var availableProperty: String = ""
+
+            private(set) var methodCallCount = 0
+            var methodHandler: (() -> Int)?
+            @discardableResult func method() -> Int {
+                methodCallCount += 1
+                if let methodHandler = methodHandler {
+                    return methodHandler()
+                }
+                return 0
+            }
+
+            var normalProperty: Bool = false
         }
-        return 0
     }
-
-    var normalProperty: Bool = false
 }
-"""
-

--- a/Tests/TestMemberAttributes/MemberAttributeTests.swift
+++ b/Tests/TestMemberAttributes/MemberAttributeTests.swift
@@ -1,0 +1,11 @@
+import Foundation
+import XCTest
+
+class MemberAttributeTests: MockoloTestCase {
+    func testMethodAndVariableAttributes() {
+        verify(srcContent: methodAndVariableAttributes,
+               dstContent: methodAndVariableAttributesMock)
+    }
+}
+
+

--- a/Tests/TestMemberAttributes/MemberAttributeTests.swift
+++ b/Tests/TestMemberAttributes/MemberAttributeTests.swift
@@ -2,9 +2,9 @@ import Foundation
 import XCTest
 
 class MemberAttributeTests: MockoloTestCase {
-    func testMethodAndVariableAttributes() {
-        verify(srcContent: methodAndVariableAttributes,
-               dstContent: methodAndVariableAttributesMock)
+    func testMemberAttributes() {
+        verify(srcContent: memberAttributes._source,
+               dstContent: memberAttributes.expected._source)
     }
 }
 

--- a/Tests/TestOverloads/FixtureDuplicatesInheritance1.swift
+++ b/Tests/TestOverloads/FixtureDuplicatesInheritance1.swift
@@ -29,7 +29,7 @@ public class ParentMock: Parent {
 
     public private(set) var updateStateCallCount = 0
     public var updateStateHandler: ((Int) -> (result: Double?, status: Bool))?
-    public func updateState(_ state: Int) -> (result: Double?, status: Bool) {
+    @discardableResult public func updateState(_ state: Int) -> (result: Double?, status: Bool) {
         updateStateCallCount += 1
         if let updateStateHandler = updateStateHandler {
             return updateStateHandler(state)
@@ -44,7 +44,7 @@ public class ChildMock: Child {
 
     public private(set) var updateStateIntCallCount = 0
     public var updateStateIntHandler: ((Int) -> (result: Double?, status: Bool))?
-    public func updateState(_ state: Int) -> (result: Double?, status: Bool) {
+    @discardableResult public func updateState(_ state: Int) -> (result: Double?, status: Bool) {
         updateStateIntCallCount += 1
         if let updateStateIntHandler = updateStateIntHandler {
             return updateStateIntHandler(state)
@@ -54,7 +54,7 @@ public class ChildMock: Child {
 
     public private(set) var updateStateCallCount = 0
     public var updateStateHandler: ((Int, SomeStyle) -> (result: Double?, status: Bool))?
-    public func updateState(_ state: Int, style: SomeStyle) -> (result: Double?, status: Bool) {
+    @discardableResult public func updateState(_ state: Int, style: SomeStyle) -> (result: Double?, status: Bool) {
         updateStateCallCount += 1
         if let updateStateHandler = updateStateHandler {
             return updateStateHandler(state, style)

--- a/Tests/TestVars/FixtureNonSimpleVars.swift
+++ b/Tests/TestVars/FixtureNonSimpleVars.swift
@@ -18,7 +18,6 @@ import MockoloFramework
     }
 
     @Fixture enum expected {
-        @available(iOS 10.0, *)
         public class NonSimpleVarsMock: NonSimpleVars {
             public init() { }
             public init(dict: Dictionary<String, Int> = Dictionary<String, Int>(), voidHandler: @escaping (() -> ()), hasDot: ModuleX.SomeType? = nil) {
@@ -27,6 +26,7 @@ import MockoloFramework
                 self.hasDot = hasDot
             }
             public private(set) var dictSetCallCount = 0
+            @available(iOS 10.0, *)
             public var dict: Dictionary<String, Int> = Dictionary<String, Int>() { didSet { dictSetCallCount += 1 } }
 
             public var closureVar: ((_ arg: String) -> Void)? = nil


### PR DESCRIPTION
## Description

Fixes #211

Member attributes like `@available`, `@objc`, and `@discardableResult` are now placed on methods and variables instead of the mock class.

## Changes

- Added `attributes` field to `MethodModel` and `VariableModel`
- Updated parsers to capture and pass member attributes
- Modified templates to render `@available` above and any other inline
- Updated test fixtures

## Testing

- All 129 tests passing
- Added `MemberAttributeTests` covering attributes on methods and variables