### PR TITLE
Fix nested bracket type overloading

### DIFF
--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -224,14 +224,7 @@ extension String {
     }
 }
 
-let separatorsForDisplay = CharacterSet(charactersIn: "<>[] :,()_-.&@#!{}@+\"\'")
-let separatorsForLiterals = CharacterSet(charactersIn: "?<>[] :,()_-.&@#!{}@+\"\'")
-
 extension StringProtocol {
-    var isNotEmpty: Bool {
-        return !isEmpty
-    }
-
     var capitalizeFirstLetter: String {
         return prefix(1).capitalized + dropFirst()
     }
@@ -250,19 +243,6 @@ extension StringProtocol {
         }
 
         return false
-    }
-
-    var literalComponents: [String] {
-        return self.components(separatedBy: separatorsForLiterals)
-    }
-
-    var displayableComponents: [String] {
-        let ret = self.replacingOccurrences(of: "?", with: "Optional")
-        return ret.components(separatedBy: separatorsForDisplay).filter {!$0.isEmpty}
-    }
-
-    var components: [String] {
-        return self.components(separatedBy: separatorsForDisplay).filter {!$0.isEmpty}
     }
 
     var asTestableImport: String {

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -148,9 +148,9 @@ struct SwiftType: Equatable, CustomStringConvertible {
         case .nominal(let nominal):
             switch nominal.name {
             case .arrayTypeSugarName where nominal.genericParameterTypes.count == 1:
-                return "Array" + nominal.genericParameterTypes[0].displayName
+                return nominal.genericParameterTypes[0].displayName + "Array"
             case .dictionaryTypeSugarName where nominal.genericParameterTypes.count == 2:
-                return "Dictionary" + nominal.genericParameterTypes[0].displayName + nominal.genericParameterTypes[1].displayName
+                return nominal.genericParameterTypes[0].displayName + nominal.genericParameterTypes[1].displayName + "Dictionary"
             case .optionalTypeSugarName where nominal.genericParameterTypes.count == 1:
                 return nominal.genericParameterTypes[0].displayName + "Optional"
             default:

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -146,19 +146,21 @@ struct SwiftType: Equatable, CustomStringConvertible {
                 return element.type.displayName
             }.joined()
         case .nominal(let nominal):
+            let name: String
             switch nominal.name {
-            case .arrayTypeSugarName where nominal.genericParameterTypes.count == 1:
-                return nominal.genericParameterTypes[0].displayName + "Array"
-            case .dictionaryTypeSugarName where nominal.genericParameterTypes.count == 2:
-                return nominal.genericParameterTypes[0].displayName + nominal.genericParameterTypes[1].displayName + "Dictionary"
-            case .optionalTypeSugarName where nominal.genericParameterTypes.count == 1:
-                return nominal.genericParameterTypes[0].displayName + "Optional"
+            case .arrayTypeSugarName: 
+                name = "Array"
+            case .dictionaryTypeSugarName:
+                name = "Dictionary"
+            case .optionalTypeSugarName:
+                name = "Optional"
             default:
-                var result = nominal.namespace.map(\.displayName) ?? ""
-                result += nominal.name.capitalizeFirstLetter
-                result += nominal.genericParameterTypes.map(\.displayName).joined()
-                return result
+                name = nominal.name.capitalizeFirstLetter
             }
+            var result = nominal.namespace.map(\.displayName) ?? ""
+            result += name
+            result += nominal.genericParameterTypes.map(\.displayName).joined()
+            return result
         case .closure(let closure):
             return closure.arguments.map(\.type.displayName).joined()
                 + closure.returning.displayName

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -137,7 +137,27 @@ struct SwiftType: Equatable, CustomStringConvertible {
 
     /// variable safe name
     var displayName: String {
+        if case .nominal(let nominal) = kind,
+           nominal.name == .arrayTypeSugarName,
+           nominal.genericParameterTypes.count == 1 {
+            let inner = nominal.genericParameterTypes[0]
+            if case .nominal(let innerNominal) = inner.kind,
+               innerNominal.name == .arrayTypeSugarName {
+                // For nested array types (e.g. [[String]]), generate "Array" × nesting depth
+                // to distinguish them from single-level arrays (e.g. [String] → "String")
+                return "Array" + inner.nestedArrayDisplayName
+            }
+        }
         return typeName.displayableComponents.map(\.capitalizeFirstLetter).joined()
+    }
+
+    private var nestedArrayDisplayName: String {
+        if case .nominal(let nominal) = kind,
+           nominal.name == .arrayTypeSugarName,
+           nominal.genericParameterTypes.count == 1 {
+            return "Array" + nominal.genericParameterTypes[0].nestedArrayDisplayName
+        }
+        return ""
     }
 
     func includingIdentifiers() -> [String] {

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -137,27 +137,34 @@ struct SwiftType: Equatable, CustomStringConvertible {
 
     /// variable safe name
     var displayName: String {
-        if case .nominal(let nominal) = kind,
-           nominal.name == .arrayTypeSugarName,
-           nominal.genericParameterTypes.count == 1 {
-            let inner = nominal.genericParameterTypes[0]
-            if case .nominal(let innerNominal) = inner.kind,
-               innerNominal.name == .arrayTypeSugarName {
-                // For nested array types (e.g. [[String]]), generate "Array" × nesting depth
-                // to distinguish them from single-level arrays (e.g. [String] → "String")
-                return "Array" + inner.nestedArrayDisplayName
+        switch kind {
+        case .tuple(let tuple):
+            return tuple.elements.map { element in
+                if let label = element.label {
+                    return label.capitalizeFirstLetter + element.type.displayName
+                }
+                return element.type.displayName
+            }.joined()
+        case .nominal(let nominal):
+            switch nominal.name {
+            case .arrayTypeSugarName where nominal.genericParameterTypes.count == 1:
+                return "Array" + nominal.genericParameterTypes[0].displayName
+            case .dictionaryTypeSugarName where nominal.genericParameterTypes.count == 2:
+                return "Dictionary" + nominal.genericParameterTypes[0].displayName + nominal.genericParameterTypes[1].displayName
+            case .optionalTypeSugarName where nominal.genericParameterTypes.count == 1:
+                return nominal.genericParameterTypes[0].displayName + "Optional"
+            default:
+                var result = nominal.namespace.map(\.displayName) ?? ""
+                result += nominal.name.capitalizeFirstLetter
+                result += nominal.genericParameterTypes.map(\.displayName).joined()
+                return result
             }
+        case .closure(let closure):
+            return closure.arguments.map(\.type.displayName).joined()
+                + closure.returning.displayName
+        case .composition(let composition):
+            return composition.elements.map(\.displayName).joined()
         }
-        return typeName.displayableComponents.map(\.capitalizeFirstLetter).joined()
-    }
-
-    private var nestedArrayDisplayName: String {
-        if case .nominal(let nominal) = kind,
-           nominal.name == .arrayTypeSugarName,
-           nominal.genericParameterTypes.count == 1 {
-            return "Array" + nominal.genericParameterTypes[0].nestedArrayDisplayName
-        }
-        return ""
     }
 
     func includingIdentifiers() -> [String] {

--- a/Tests/TestOverloads/FixtureDuplicates6.swift
+++ b/Tests/TestOverloads/FixtureDuplicates6.swift
@@ -1,0 +1,34 @@
+@Fixture enum overloadReturningBracketType {
+    /// @mockable
+    protocol P {
+        func foo() -> [String]
+        func foo() -> [[String]]
+    }
+
+    @Fixture enum expected {
+        class PMock: P {
+            init() { }
+
+
+            private(set) var fooCallCount = 0
+            var fooHandler: (() -> [String])?
+            func foo() -> [String] {
+                fooCallCount += 1
+                if let fooHandler = fooHandler {
+                    return fooHandler()
+                }
+                return [String]()
+            }
+
+            private(set) var fooArrayArrayCallCount = 0
+            var fooArrayArrayHandler: (() -> [[String]])?
+            func foo() -> [[String]] {
+                fooArrayArrayCallCount += 1
+                if let fooArrayArrayHandler = fooArrayArrayHandler {
+                    return fooArrayArrayHandler()
+                }
+                return [[String]]()
+            }
+        }
+    }
+}

--- a/Tests/TestOverloads/FixtureDuplicates6.swift
+++ b/Tests/TestOverloads/FixtureDuplicates6.swift
@@ -20,12 +20,12 @@
                 return [String]()
             }
 
-            private(set) var fooStringArrayArrayCallCount = 0
-            var fooStringArrayArrayHandler: (() -> [[String]])?
+            private(set) var fooArrayArrayStringCallCount = 0
+            var fooArrayArrayStringHandler: (() -> [[String]])?
             func foo() -> [[String]] {
-                fooStringArrayArrayCallCount += 1
-                if let fooStringArrayArrayHandler = fooStringArrayArrayHandler {
-                    return fooStringArrayArrayHandler()
+                fooArrayArrayStringCallCount += 1
+                if let fooArrayArrayStringHandler = fooArrayArrayStringHandler {
+                    return fooArrayArrayStringHandler()
                 }
                 return [[String]]()
             }

--- a/Tests/TestOverloads/FixtureDuplicates6.swift
+++ b/Tests/TestOverloads/FixtureDuplicates6.swift
@@ -20,12 +20,12 @@
                 return [String]()
             }
 
-            private(set) var fooArrayArrayCallCount = 0
-            var fooArrayArrayHandler: (() -> [[String]])?
+            private(set) var fooArrayArrayStringCallCount = 0
+            var fooArrayArrayStringHandler: (() -> [[String]])?
             func foo() -> [[String]] {
-                fooArrayArrayCallCount += 1
-                if let fooArrayArrayHandler = fooArrayArrayHandler {
-                    return fooArrayArrayHandler()
+                fooArrayArrayStringCallCount += 1
+                if let fooArrayArrayStringHandler = fooArrayArrayStringHandler {
+                    return fooArrayArrayStringHandler()
                 }
                 return [[String]]()
             }

--- a/Tests/TestOverloads/FixtureDuplicates6.swift
+++ b/Tests/TestOverloads/FixtureDuplicates6.swift
@@ -20,12 +20,12 @@
                 return [String]()
             }
 
-            private(set) var fooArrayArrayStringCallCount = 0
-            var fooArrayArrayStringHandler: (() -> [[String]])?
+            private(set) var fooStringArrayArrayCallCount = 0
+            var fooStringArrayArrayHandler: (() -> [[String]])?
             func foo() -> [[String]] {
-                fooArrayArrayStringCallCount += 1
-                if let fooArrayArrayStringHandler = fooArrayArrayStringHandler {
-                    return fooArrayArrayStringHandler()
+                fooStringArrayArrayCallCount += 1
+                if let fooStringArrayArrayHandler = fooStringArrayArrayHandler {
+                    return fooStringArrayArrayHandler()
                 }
                 return [[String]]()
             }

--- a/Tests/TestOverloads/OverloadTests.swift
+++ b/Tests/TestOverloads/OverloadTests.swift
@@ -81,5 +81,11 @@ class OverloadTests: MockoloTestCase {
             dstContent: compositionInheritanceMock
         )
     }
-    
+
+    func testOverloadReturningBracketType() {
+        verify(
+            srcContent: overloadReturningBracketType._source,
+            dstContent: overloadReturningBracketType.expected._source
+        )
+    }
 }

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -68,44 +68,34 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return Observable<(ItemType, ())>.empty()
     }
 
-    private(set) var updateObservableItemTypeOptionalCallCount = 0
-    var updateObservableItemTypeOptionalHandler: (() -> Observable<(ItemType, ())>?)?
+    private(set) var updateOptionalObservableItemTypeCallCount = 0
+    var updateOptionalObservableItemTypeHandler: (() -> Observable<(ItemType, ())>?)?
     func update() -> Observable<(ItemType, ())>? {
-        updateObservableItemTypeOptionalCallCount += 1
-        if let updateObservableItemTypeOptionalHandler = updateObservableItemTypeOptionalHandler {
-            return updateObservableItemTypeOptionalHandler()
+        updateOptionalObservableItemTypeCallCount += 1
+        if let updateOptionalObservableItemTypeHandler = updateOptionalObservableItemTypeHandler {
+            return updateOptionalObservableItemTypeHandler()
         }
         return nil
     }
 
-    private(set) var updateObservableSomeKeySomeTypeDictionCallCount = 0
-    var updateObservableSomeKeySomeTypeDictionHandler: (() -> Observable<[SomeKey: SomeType]>)?
+    private(set) var updateObservableDictionarySomeKeySomeTCallCount = 0
+    var updateObservableDictionarySomeKeySomeTHandler: (() -> Observable<[SomeKey: SomeType]>)?
     func update() -> Observable<[SomeKey: SomeType]> {
-        updateObservableSomeKeySomeTypeDictionCallCount += 1
-        if let updateObservableSomeKeySomeTypeDictionHandler = updateObservableSomeKeySomeTypeDictionHandler {
-            return updateObservableSomeKeySomeTypeDictionHandler()
+        updateObservableDictionarySomeKeySomeTCallCount += 1
+        if let updateObservableDictionarySomeKeySomeTHandler = updateObservableDictionarySomeKeySomeTHandler {
+            return updateObservableDictionarySomeKeySomeTHandler()
         }
         return Observable<[SomeKey: SomeType]>.empty()
     }
 
-    private(set) var updateStringIntDictionaryCallCount = 0
-    var updateStringIntDictionaryHandler: (() -> [String: Int])?
-    func update() -> [String: Int] {
-        updateStringIntDictionaryCallCount += 1
-        if let updateStringIntDictionaryHandler = updateStringIntDictionaryHandler {
-            return updateStringIntDictionaryHandler()
-        }
-        return [String: Int]()
-    }
-
     private(set) var updateDictionaryStringIntCallCount = 0
-    var updateDictionaryStringIntHandler: (() -> Dictionary<String, Int>)?
-    func update() -> Dictionary<String, Int> {
+    var updateDictionaryStringIntHandler: (() -> [String: Int])?
+    func update() -> [String: Int] {
         updateDictionaryStringIntCallCount += 1
         if let updateDictionaryStringIntHandler = updateDictionaryStringIntHandler {
             return updateDictionaryStringIntHandler()
         }
-        return Dictionary<String, Int>()
+        return [String: Int]()
     }
 
     private(set) var updateObservableDoubleFloatCallCount = 0
@@ -118,74 +108,64 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return Observable<Double, Float>.empty()
     }
 
-    private(set) var updateStringArrayCallCount = 0
-    var updateStringArrayHandler: (() -> [String])?
+    private(set) var updateArrayStringCallCount = 0
+    var updateArrayStringHandler: (() -> [String])?
     func update() -> [String] {
-        updateStringArrayCallCount += 1
-        if let updateStringArrayHandler = updateStringArrayHandler {
-            return updateStringArrayHandler()
+        updateArrayStringCallCount += 1
+        if let updateArrayStringHandler = updateArrayStringHandler {
+            return updateArrayStringHandler()
         }
         return [String]()
     }
 
-    private(set) var updateStringArrayArrayCallCount = 0
-    var updateStringArrayArrayHandler: (() -> [[String]])?
+    private(set) var updateArrayArrayStringCallCount = 0
+    var updateArrayArrayStringHandler: (() -> [[String]])?
     func update() -> [[String]] {
-        updateStringArrayArrayCallCount += 1
-        if let updateStringArrayArrayHandler = updateStringArrayArrayHandler {
-            return updateStringArrayArrayHandler()
+        updateArrayArrayStringCallCount += 1
+        if let updateArrayArrayStringHandler = updateArrayArrayStringHandler {
+            return updateArrayArrayStringHandler()
         }
         return [[String]]()
     }
 
-    private(set) var updateStringArrayIntDictionaryCallCount = 0
-    var updateStringArrayIntDictionaryHandler: (() -> [String: Array<Int>])?
+    private(set) var updateDictionaryStringArrayIntCallCount = 0
+    var updateDictionaryStringArrayIntHandler: (() -> [String: Array<Int>])?
     func update() -> [String: Array<Int>] {
-        updateStringArrayIntDictionaryCallCount += 1
-        if let updateStringArrayIntDictionaryHandler = updateStringArrayIntDictionaryHandler {
-            return updateStringArrayIntDictionaryHandler()
+        updateDictionaryStringArrayIntCallCount += 1
+        if let updateDictionaryStringArrayIntHandler = updateDictionaryStringArrayIntHandler {
+            return updateDictionaryStringArrayIntHandler()
         }
         return [String: Array<Int>]()
     }
 
-    private(set) var updateStringDictionaryIntDoubleDictionCallCount = 0
-    var updateStringDictionaryIntDoubleDictionHandler: (() -> [String: Dictionary<Int, Double>])?
+    private(set) var updateDictionaryStringDictionaryIntDouCallCount = 0
+    var updateDictionaryStringDictionaryIntDouHandler: (() -> [String: Dictionary<Int, Double>])?
     func update() -> [String: Dictionary<Int, Double>] {
-        updateStringDictionaryIntDoubleDictionCallCount += 1
-        if let updateStringDictionaryIntDoubleDictionHandler = updateStringDictionaryIntDoubleDictionHandler {
-            return updateStringDictionaryIntDoubleDictionHandler()
+        updateDictionaryStringDictionaryIntDouCallCount += 1
+        if let updateDictionaryStringDictionaryIntDouHandler = updateDictionaryStringDictionaryIntDouHandler {
+            return updateDictionaryStringDictionaryIntDouHandler()
         }
         return [String: Dictionary<Int, Double>]()
     }
 
-    private(set) var updateStringArrayArrayIntArrayArrayStrCallCount = 0
-    var updateStringArrayArrayIntArrayArrayStrHandler: (() -> ([[String]], [Int], Array<[String]>))?
+    private(set) var updateArrayArrayStringArrayIntArrayArrCallCount = 0
+    var updateArrayArrayStringArrayIntArrayArrHandler: (() -> ([[String]], [Int], Array<[String]>))?
     func update() -> ([[String]], [Int], Array<[String]>) {
-        updateStringArrayArrayIntArrayArrayStrCallCount += 1
-        if let updateStringArrayArrayIntArrayArrayStrHandler = updateStringArrayArrayIntArrayArrayStrHandler {
-            return updateStringArrayArrayIntArrayArrayStrHandler()
+        updateArrayArrayStringArrayIntArrayArrCallCount += 1
+        if let updateArrayArrayStringArrayIntArrayArrHandler = updateArrayArrayStringArrayIntArrayArrHandler {
+            return updateArrayArrayStringArrayIntArrayArrHandler()
         }
         return ([[String]](), [Int](), Array<[String]>())
     }
 
-    private(set) var updateArrayStringIntDictionaryCallCount = 0
-    var updateArrayStringIntDictionaryHandler: (() -> Array<[String: Int]>)?
-    func update() -> Array<[String: Int]> {
-        updateArrayStringIntDictionaryCallCount += 1
-        if let updateArrayStringIntDictionaryHandler = updateArrayStringIntDictionaryHandler {
-            return updateArrayStringIntDictionaryHandler()
-        }
-        return Array<[String: Int]>()
-    }
-
     private(set) var updateArrayDictionaryStringIntCallCount = 0
-    var updateArrayDictionaryStringIntHandler: (() -> Array<Dictionary<String, Int>>)?
-    func update() -> Array<Dictionary<String, Int>> {
+    var updateArrayDictionaryStringIntHandler: (() -> Array<[String: Int]>)?
+    func update() -> Array<[String: Int]> {
         updateArrayDictionaryStringIntCallCount += 1
         if let updateArrayDictionaryStringIntHandler = updateArrayDictionaryStringIntHandler {
             return updateArrayDictionaryStringIntHandler()
         }
-        return Array<Dictionary<String, Int>>()
+        return Array<[String: Int]>()
     }
 
     private(set) var updateArrayStringArrayIntCallCount = 0
@@ -198,22 +178,12 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return (Array<String>(), Array<Int>())
     }
 
-    private(set) var updateArrayStringCallCount = 0
-    var updateArrayStringHandler: (() -> Array<String>)?
-    func update() -> Array<String> {
-        updateArrayStringCallCount += 1
-        if let updateArrayStringHandler = updateArrayStringHandler {
-            return updateArrayStringHandler()
-        }
-        return Array<String>()
-    }
-
-    private(set) var updateResultDoubleOptionalStatusBoolCallCount = 0
-    var updateResultDoubleOptionalStatusBoolHandler: (() -> (result: Double?, status: Bool))?
+    private(set) var updateResultOptionalDoubleStatusBoolCallCount = 0
+    var updateResultOptionalDoubleStatusBoolHandler: (() -> (result: Double?, status: Bool))?
     func update() -> (result: Double?, status: Bool) {
-        updateResultDoubleOptionalStatusBoolCallCount += 1
-        if let updateResultDoubleOptionalStatusBoolHandler = updateResultDoubleOptionalStatusBoolHandler {
-            return updateResultDoubleOptionalStatusBoolHandler()
+        updateResultOptionalDoubleStatusBoolCallCount += 1
+        if let updateResultOptionalDoubleStatusBoolHandler = updateResultOptionalDoubleStatusBoolHandler {
+            return updateResultOptionalDoubleStatusBoolHandler()
         }
         return (nil, false)
     }

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -78,34 +78,24 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return nil
     }
 
-    private(set) var updateObservableSomeKeySomeTypeCallCount = 0
-    var updateObservableSomeKeySomeTypeHandler: (() -> Observable<[SomeKey: SomeType]>)?
+    private(set) var updateObservableDictionarySomeKeySomeTCallCount = 0
+    var updateObservableDictionarySomeKeySomeTHandler: (() -> Observable<[SomeKey: SomeType]>)?
     func update() -> Observable<[SomeKey: SomeType]> {
-        updateObservableSomeKeySomeTypeCallCount += 1
-        if let updateObservableSomeKeySomeTypeHandler = updateObservableSomeKeySomeTypeHandler {
-            return updateObservableSomeKeySomeTypeHandler()
+        updateObservableDictionarySomeKeySomeTCallCount += 1
+        if let updateObservableDictionarySomeKeySomeTHandler = updateObservableDictionarySomeKeySomeTHandler {
+            return updateObservableDictionarySomeKeySomeTHandler()
         }
         return Observable<[SomeKey: SomeType]>.empty()
     }
 
-    private(set) var updateStringIntCallCount = 0
-    var updateStringIntHandler: (() -> [String: Int])?
-    func update() -> [String: Int] {
-        updateStringIntCallCount += 1
-        if let updateStringIntHandler = updateStringIntHandler {
-            return updateStringIntHandler()
-        }
-        return [String: Int]()
-    }
-
     private(set) var updateDictionaryStringIntCallCount = 0
-    var updateDictionaryStringIntHandler: (() -> Dictionary<String, Int>)?
-    func update() -> Dictionary<String, Int> {
+    var updateDictionaryStringIntHandler: (() -> [String: Int])?
+    func update() -> [String: Int] {
         updateDictionaryStringIntCallCount += 1
         if let updateDictionaryStringIntHandler = updateDictionaryStringIntHandler {
             return updateDictionaryStringIntHandler()
         }
-        return Dictionary<String, Int>()
+        return [String: Int]()
     }
 
     private(set) var updateObservableDoubleFloatCallCount = 0
@@ -118,74 +108,64 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return Observable<Double, Float>.empty()
     }
 
-    private(set) var updateStringCallCount = 0
-    var updateStringHandler: (() -> [String])?
+    private(set) var updateArrayStringCallCount = 0
+    var updateArrayStringHandler: (() -> [String])?
     func update() -> [String] {
-        updateStringCallCount += 1
-        if let updateStringHandler = updateStringHandler {
-            return updateStringHandler()
+        updateArrayStringCallCount += 1
+        if let updateArrayStringHandler = updateArrayStringHandler {
+            return updateArrayStringHandler()
         }
         return [String]()
     }
 
-    private(set) var updateArrayArrayCallCount = 0
-    var updateArrayArrayHandler: (() -> [[String]])?
+    private(set) var updateArrayArrayStringCallCount = 0
+    var updateArrayArrayStringHandler: (() -> [[String]])?
     func update() -> [[String]] {
-        updateArrayArrayCallCount += 1
-        if let updateArrayArrayHandler = updateArrayArrayHandler {
-            return updateArrayArrayHandler()
+        updateArrayArrayStringCallCount += 1
+        if let updateArrayArrayStringHandler = updateArrayArrayStringHandler {
+            return updateArrayArrayStringHandler()
         }
         return [[String]]()
     }
 
-    private(set) var updateStringArrayIntCallCount = 0
-    var updateStringArrayIntHandler: (() -> [String: Array<Int>])?
+    private(set) var updateDictionaryStringArrayIntCallCount = 0
+    var updateDictionaryStringArrayIntHandler: (() -> [String: Array<Int>])?
     func update() -> [String: Array<Int>] {
-        updateStringArrayIntCallCount += 1
-        if let updateStringArrayIntHandler = updateStringArrayIntHandler {
-            return updateStringArrayIntHandler()
+        updateDictionaryStringArrayIntCallCount += 1
+        if let updateDictionaryStringArrayIntHandler = updateDictionaryStringArrayIntHandler {
+            return updateDictionaryStringArrayIntHandler()
         }
         return [String: Array<Int>]()
     }
 
-    private(set) var updateStringDictionaryIntDoubleCallCount = 0
-    var updateStringDictionaryIntDoubleHandler: (() -> [String: Dictionary<Int, Double>])?
+    private(set) var updateDictionaryStringDictionaryIntDouCallCount = 0
+    var updateDictionaryStringDictionaryIntDouHandler: (() -> [String: Dictionary<Int, Double>])?
     func update() -> [String: Dictionary<Int, Double>] {
-        updateStringDictionaryIntDoubleCallCount += 1
-        if let updateStringDictionaryIntDoubleHandler = updateStringDictionaryIntDoubleHandler {
-            return updateStringDictionaryIntDoubleHandler()
+        updateDictionaryStringDictionaryIntDouCallCount += 1
+        if let updateDictionaryStringDictionaryIntDouHandler = updateDictionaryStringDictionaryIntDouHandler {
+            return updateDictionaryStringDictionaryIntDouHandler()
         }
         return [String: Dictionary<Int, Double>]()
     }
 
-    private(set) var updateStringIntArrayStringCallCount = 0
-    var updateStringIntArrayStringHandler: (() -> ([[String]], [Int], Array<[String]>))?
+    private(set) var updateArrayArrayStringArrayIntArrayArrCallCount = 0
+    var updateArrayArrayStringArrayIntArrayArrHandler: (() -> ([[String]], [Int], Array<[String]>))?
     func update() -> ([[String]], [Int], Array<[String]>) {
-        updateStringIntArrayStringCallCount += 1
-        if let updateStringIntArrayStringHandler = updateStringIntArrayStringHandler {
-            return updateStringIntArrayStringHandler()
+        updateArrayArrayStringArrayIntArrayArrCallCount += 1
+        if let updateArrayArrayStringArrayIntArrayArrHandler = updateArrayArrayStringArrayIntArrayArrHandler {
+            return updateArrayArrayStringArrayIntArrayArrHandler()
         }
         return ([[String]](), [Int](), Array<[String]>())
     }
 
-    private(set) var updateArrayStringIntCallCount = 0
-    var updateArrayStringIntHandler: (() -> Array<[String: Int]>)?
-    func update() -> Array<[String: Int]> {
-        updateArrayStringIntCallCount += 1
-        if let updateArrayStringIntHandler = updateArrayStringIntHandler {
-            return updateArrayStringIntHandler()
-        }
-        return Array<[String: Int]>()
-    }
-
     private(set) var updateArrayDictionaryStringIntCallCount = 0
-    var updateArrayDictionaryStringIntHandler: (() -> Array<Dictionary<String, Int>>)?
-    func update() -> Array<Dictionary<String, Int>> {
+    var updateArrayDictionaryStringIntHandler: (() -> Array<[String: Int]>)?
+    func update() -> Array<[String: Int]> {
         updateArrayDictionaryStringIntCallCount += 1
         if let updateArrayDictionaryStringIntHandler = updateArrayDictionaryStringIntHandler {
             return updateArrayDictionaryStringIntHandler()
         }
-        return Array<Dictionary<String, Int>>()
+        return Array<[String: Int]>()
     }
 
     private(set) var updateArrayStringArrayIntCallCount = 0
@@ -196,16 +176,6 @@ class NonSimpleTypesMock: NonSimpleTypes {
             return updateArrayStringArrayIntHandler()
         }
         return (Array<String>(), Array<Int>())
-    }
-
-    private(set) var updateArrayStringCallCount = 0
-    var updateArrayStringHandler: (() -> Array<String>)?
-    func update() -> Array<String> {
-        updateArrayStringCallCount += 1
-        if let updateArrayStringHandler = updateArrayStringHandler {
-            return updateArrayStringHandler()
-        }
-        return Array<String>()
     }
 
     private(set) var updateResultDoubleOptionalStatusBoolCallCount = 0

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -128,6 +128,16 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return [String]()
     }
 
+    private(set) var updateArrayArrayCallCount = 0
+    var updateArrayArrayHandler: (() -> [[String]])?
+    func update() -> [[String]] {
+        updateArrayArrayCallCount += 1
+        if let updateArrayArrayHandler = updateArrayArrayHandler {
+            return updateArrayArrayHandler()
+        }
+        return [[String]]()
+    }
+
     private(set) var updateStringArrayIntCallCount = 0
     var updateStringArrayIntHandler: (() -> [String: Array<Int>])?
     func update() -> [String: Array<Int>] {

--- a/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
+++ b/Tests/TestTuplesBrackets/FixtureTuplesBrackets.swift
@@ -78,24 +78,34 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return nil
     }
 
-    private(set) var updateObservableDictionarySomeKeySomeTCallCount = 0
-    var updateObservableDictionarySomeKeySomeTHandler: (() -> Observable<[SomeKey: SomeType]>)?
+    private(set) var updateObservableSomeKeySomeTypeDictionCallCount = 0
+    var updateObservableSomeKeySomeTypeDictionHandler: (() -> Observable<[SomeKey: SomeType]>)?
     func update() -> Observable<[SomeKey: SomeType]> {
-        updateObservableDictionarySomeKeySomeTCallCount += 1
-        if let updateObservableDictionarySomeKeySomeTHandler = updateObservableDictionarySomeKeySomeTHandler {
-            return updateObservableDictionarySomeKeySomeTHandler()
+        updateObservableSomeKeySomeTypeDictionCallCount += 1
+        if let updateObservableSomeKeySomeTypeDictionHandler = updateObservableSomeKeySomeTypeDictionHandler {
+            return updateObservableSomeKeySomeTypeDictionHandler()
         }
         return Observable<[SomeKey: SomeType]>.empty()
     }
 
-    private(set) var updateDictionaryStringIntCallCount = 0
-    var updateDictionaryStringIntHandler: (() -> [String: Int])?
+    private(set) var updateStringIntDictionaryCallCount = 0
+    var updateStringIntDictionaryHandler: (() -> [String: Int])?
     func update() -> [String: Int] {
+        updateStringIntDictionaryCallCount += 1
+        if let updateStringIntDictionaryHandler = updateStringIntDictionaryHandler {
+            return updateStringIntDictionaryHandler()
+        }
+        return [String: Int]()
+    }
+
+    private(set) var updateDictionaryStringIntCallCount = 0
+    var updateDictionaryStringIntHandler: (() -> Dictionary<String, Int>)?
+    func update() -> Dictionary<String, Int> {
         updateDictionaryStringIntCallCount += 1
         if let updateDictionaryStringIntHandler = updateDictionaryStringIntHandler {
             return updateDictionaryStringIntHandler()
         }
-        return [String: Int]()
+        return Dictionary<String, Int>()
     }
 
     private(set) var updateObservableDoubleFloatCallCount = 0
@@ -108,64 +118,74 @@ class NonSimpleTypesMock: NonSimpleTypes {
         return Observable<Double, Float>.empty()
     }
 
-    private(set) var updateArrayStringCallCount = 0
-    var updateArrayStringHandler: (() -> [String])?
+    private(set) var updateStringArrayCallCount = 0
+    var updateStringArrayHandler: (() -> [String])?
     func update() -> [String] {
-        updateArrayStringCallCount += 1
-        if let updateArrayStringHandler = updateArrayStringHandler {
-            return updateArrayStringHandler()
+        updateStringArrayCallCount += 1
+        if let updateStringArrayHandler = updateStringArrayHandler {
+            return updateStringArrayHandler()
         }
         return [String]()
     }
 
-    private(set) var updateArrayArrayStringCallCount = 0
-    var updateArrayArrayStringHandler: (() -> [[String]])?
+    private(set) var updateStringArrayArrayCallCount = 0
+    var updateStringArrayArrayHandler: (() -> [[String]])?
     func update() -> [[String]] {
-        updateArrayArrayStringCallCount += 1
-        if let updateArrayArrayStringHandler = updateArrayArrayStringHandler {
-            return updateArrayArrayStringHandler()
+        updateStringArrayArrayCallCount += 1
+        if let updateStringArrayArrayHandler = updateStringArrayArrayHandler {
+            return updateStringArrayArrayHandler()
         }
         return [[String]]()
     }
 
-    private(set) var updateDictionaryStringArrayIntCallCount = 0
-    var updateDictionaryStringArrayIntHandler: (() -> [String: Array<Int>])?
+    private(set) var updateStringArrayIntDictionaryCallCount = 0
+    var updateStringArrayIntDictionaryHandler: (() -> [String: Array<Int>])?
     func update() -> [String: Array<Int>] {
-        updateDictionaryStringArrayIntCallCount += 1
-        if let updateDictionaryStringArrayIntHandler = updateDictionaryStringArrayIntHandler {
-            return updateDictionaryStringArrayIntHandler()
+        updateStringArrayIntDictionaryCallCount += 1
+        if let updateStringArrayIntDictionaryHandler = updateStringArrayIntDictionaryHandler {
+            return updateStringArrayIntDictionaryHandler()
         }
         return [String: Array<Int>]()
     }
 
-    private(set) var updateDictionaryStringDictionaryIntDouCallCount = 0
-    var updateDictionaryStringDictionaryIntDouHandler: (() -> [String: Dictionary<Int, Double>])?
+    private(set) var updateStringDictionaryIntDoubleDictionCallCount = 0
+    var updateStringDictionaryIntDoubleDictionHandler: (() -> [String: Dictionary<Int, Double>])?
     func update() -> [String: Dictionary<Int, Double>] {
-        updateDictionaryStringDictionaryIntDouCallCount += 1
-        if let updateDictionaryStringDictionaryIntDouHandler = updateDictionaryStringDictionaryIntDouHandler {
-            return updateDictionaryStringDictionaryIntDouHandler()
+        updateStringDictionaryIntDoubleDictionCallCount += 1
+        if let updateStringDictionaryIntDoubleDictionHandler = updateStringDictionaryIntDoubleDictionHandler {
+            return updateStringDictionaryIntDoubleDictionHandler()
         }
         return [String: Dictionary<Int, Double>]()
     }
 
-    private(set) var updateArrayArrayStringArrayIntArrayArrCallCount = 0
-    var updateArrayArrayStringArrayIntArrayArrHandler: (() -> ([[String]], [Int], Array<[String]>))?
+    private(set) var updateStringArrayArrayIntArrayArrayStrCallCount = 0
+    var updateStringArrayArrayIntArrayArrayStrHandler: (() -> ([[String]], [Int], Array<[String]>))?
     func update() -> ([[String]], [Int], Array<[String]>) {
-        updateArrayArrayStringArrayIntArrayArrCallCount += 1
-        if let updateArrayArrayStringArrayIntArrayArrHandler = updateArrayArrayStringArrayIntArrayArrHandler {
-            return updateArrayArrayStringArrayIntArrayArrHandler()
+        updateStringArrayArrayIntArrayArrayStrCallCount += 1
+        if let updateStringArrayArrayIntArrayArrayStrHandler = updateStringArrayArrayIntArrayArrayStrHandler {
+            return updateStringArrayArrayIntArrayArrayStrHandler()
         }
         return ([[String]](), [Int](), Array<[String]>())
     }
 
-    private(set) var updateArrayDictionaryStringIntCallCount = 0
-    var updateArrayDictionaryStringIntHandler: (() -> Array<[String: Int]>)?
+    private(set) var updateArrayStringIntDictionaryCallCount = 0
+    var updateArrayStringIntDictionaryHandler: (() -> Array<[String: Int]>)?
     func update() -> Array<[String: Int]> {
+        updateArrayStringIntDictionaryCallCount += 1
+        if let updateArrayStringIntDictionaryHandler = updateArrayStringIntDictionaryHandler {
+            return updateArrayStringIntDictionaryHandler()
+        }
+        return Array<[String: Int]>()
+    }
+
+    private(set) var updateArrayDictionaryStringIntCallCount = 0
+    var updateArrayDictionaryStringIntHandler: (() -> Array<Dictionary<String, Int>>)?
+    func update() -> Array<Dictionary<String, Int>> {
         updateArrayDictionaryStringIntCallCount += 1
         if let updateArrayDictionaryStringIntHandler = updateArrayDictionaryStringIntHandler {
             return updateArrayDictionaryStringIntHandler()
         }
-        return Array<[String: Int]>()
+        return Array<Dictionary<String, Int>>()
     }
 
     private(set) var updateArrayStringArrayIntCallCount = 0
@@ -176,6 +196,16 @@ class NonSimpleTypesMock: NonSimpleTypes {
             return updateArrayStringArrayIntHandler()
         }
         return (Array<String>(), Array<Int>())
+    }
+
+    private(set) var updateArrayStringCallCount = 0
+    var updateArrayStringHandler: (() -> Array<String>)?
+    func update() -> Array<String> {
+        updateArrayStringCallCount += 1
+        if let updateArrayStringHandler = updateArrayStringHandler {
+            return updateArrayStringHandler()
+        }
+        return Array<String>()
     }
 
     private(set) var updateResultDoubleOptionalStatusBoolCallCount = 0


### PR DESCRIPTION
Previously, mockolo fails to generate overloads for nested types like arrays.
Consider the following code, which only produces a single `foo` function for mock class.

```swift
    /// @mockable
    protocol P {
        func foo() -> [String]
        func foo() -> [[String]]
    }
```

The issue stems from `SwiftType.displayName` continuing to use a legacy ad-hoc implementation, resulting in both `[String]` and `[[String]]` being rendered as the same `String`.
I'll modify the implementation to properly construct `displayName` in a structured manner.
