### PR TITLE
ci: declare contents:read on Build Actions workflow

### DIFF
--- a/.github/workflows/builds.yml
+++ b/.github/workflows/builds.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
   run:
     name: Test on ${{ matrix.os }} - ${{ matrix.version }}


### PR DESCRIPTION
Pins `builds.yml` to `contents: read` at workflow scope. The matrix only installs swiftly/Xcode, checks out, and runs `swift test`. No GitHub API write, no cache plumbing.

Defense-in-depth motivation is [CVE-2025-30066](https://github.com/advisories/GHSA-mrrh-fwg8-r2c3) on `tj-actions/changed-files`: a compromised third-party action runs inside the existing job context and exfiltrates the workflow `GITHUB_TOKEN` via build logs. `vapor/swiftly-action` is third-party here, so the cap is meaningful.

YAML validated locally with `yaml.safe_load`.