### PR TITLE
Fix IUO type rendering so `T!` no longer generates `T?!`

### DIFF
--- a/Sources/MockoloFramework/Utils/StringExtensions.swift
+++ b/Sources/MockoloFramework/Utils/StringExtensions.swift
@@ -119,6 +119,7 @@ extension String {
     static let arrayTypeSugarName = "[]"
     static let dictionaryTypeSugarName = "[:]"
     static let optionalTypeSugarName = "?"
+    static let optionalAutounwrappedTypeSugarName = "!"
 
     var safeName: String {
         var text = self

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -57,7 +57,6 @@ struct SwiftType: Equatable, CustomStringConvertible {
     var kind: Kind
     var attributes: [String] = []
     var someOrAny: SomeOrAny?
-    var isIUO: Bool = false
     var hasEllipsis: Bool = false
 
     var typeName: String {
@@ -87,9 +86,9 @@ struct SwiftType: Equatable, CustomStringConvertible {
 
             switch nominal.name {
             case .optionalTypeSugarName where nominal.genericParameterTypes.count == 1:
-                // For an IUO (`T!`, stored as Optional<T> + isIUO) the `!` is appended by the isIUO
-                // block below; emitting `?` here too would wrongly render `T?!`.
-                repr += "\(nominal.genericParameterTypes[0])\(isIUO ? "" : "?")"
+                repr += "\(nominal.genericParameterTypes[0])?"
+            case .optionalAutounwrappedTypeSugarName where nominal.genericParameterTypes.count == 1:
+                repr += "\(nominal.genericParameterTypes[0])!"
             case .arrayTypeSugarName where nominal.genericParameterTypes.count == 1:
                 repr += "[\(nominal.genericParameterTypes[0])]"
             case .dictionaryTypeSugarName where nominal.genericParameterTypes.count == 2:
@@ -122,14 +121,6 @@ struct SwiftType: Equatable, CustomStringConvertible {
             repr += closureDesc
         case .composition(let composition):
             repr += composition.elements.map(\.description).joined(separator: " & ")
-        }
-        if isIUO {
-            switch kind {
-            case .tuple, .nominal:
-                repr += "!"
-            case .closure, .composition:
-                repr = "(\(repr))!"
-            }
         }
         if hasEllipsis {
             repr += "..."
@@ -193,7 +184,11 @@ struct SwiftType: Equatable, CustomStringConvertible {
     }
 
     var isOptional: Bool {
-        isNominal(named: .optional) || isNominal(named: .optionalTypeSugarName)
+        isNominal(named: .optional) || isNominal(named: .optionalTypeSugarName) || isNominal(named: .optionalAutounwrappedTypeSugarName)
+    }
+
+    var isIUO: Bool {
+        isNominal(named: .optionalAutounwrappedTypeSugarName)
     }
 
     var isSelf: Bool {
@@ -288,9 +283,8 @@ struct SwiftType: Equatable, CustomStringConvertible {
                 ret = unwrapped
             }
         }
-        ret.isIUO = true
 
-        return ret.description
+        return ret.iuoWrapped().description
     }
 
     func defaultVal(with overrides: [String: String]? = nil, overrideKey: String = "", isInitParam: Bool = false) -> String? {
@@ -345,7 +339,7 @@ struct SwiftType: Equatable, CustomStringConvertible {
             var processedType = subtype.processTypeParams(with: typeParams)
             processedType.attributes.removeAll(where: { $0 == .inout })
             processedType.attributes.removeAll(where: { $0 == .escaping })
-            processedType.isIUO = false
+            processedType.unwrapIUO()
             return processedType
         }
 
@@ -458,10 +452,9 @@ struct SwiftType: Equatable, CustomStringConvertible {
                 returnAsType = unwrapped
                 asSuffix = "?"
             } else if returnType.isIUO {
-                displayableReturnType = .Any
-                displayableReturnType.isIUO = true
+                displayableReturnType = .Any.iuoWrapped()
                 var asType = returnType
-                asType.isIUO = false
+                asType.unwrapIUO()
                 returnAsType = asType
             } else if returnType.isSelf {
                 returnAsType = .Self
@@ -479,16 +472,15 @@ struct SwiftType: Equatable, CustomStringConvertible {
         }
 
         // `!` (IUO) is illegal inside a closure type, so an IUO param/return must render as a plain
-        // optional here (it still witnesses the IUO requirement). Clearing `isIUO` is a no-op for
-        // every non-IUO type, so existing handlers are unaffected.
-        displayableReturnType.isIUO = false
+        // optional here (it still witnesses the IUO requirement).
+        displayableReturnType.unwrapIUO()
         var resultType = SwiftType(
             kind: .closure(.init(
                 isAsync: isAsync,
                 throwing: throwing,
                 arguments: params.map {
                     var argType = $0.processTypeParams(with: typeParams)
-                    argType.isIUO = false
+                    argType.unwrapIUO()
                     return .init(type: argType)
                 },
                 returning: displayableReturnType
@@ -640,8 +632,7 @@ extension SwiftType {
         case .implicitlyUnwrappedOptionalType(let syntax):
             // T!
             let base = SwiftType(typeSyntax: syntax.wrappedType)
-            self = base.optionalWrapped()
-            self.isIUO = true
+            self = base.iuoWrapped()
 
         case .identifierType(let syntax):
             // T<U>
@@ -730,6 +721,12 @@ extension SwiftType {
         )
     }
 
+    func iuoWrapped() -> SwiftType {
+        return copy(
+            kind: .nominal(.init(name: .optionalAutounwrappedTypeSugarName, genericParameterTypes: [.init(kind: kind)]))
+        )
+    }
+
     func optionalUnwrapped() -> SwiftType? {
         guard isOptional else {
             return nil
@@ -738,6 +735,17 @@ extension SwiftType {
             return nil
         }
         return nominal.genericParameterTypes.first
+    }
+
+    mutating func unwrapIUO() {
+        guard isNominal(named: .optionalAutounwrappedTypeSugarName) else {
+            return
+        }
+        guard case .nominal(let nominal) = kind,
+            let wrapped = nominal.genericParameterTypes.first else {
+            return
+        }
+        self = wrapped
     }
 
     func copy(kind: Kind) -> Self {

--- a/Sources/MockoloFramework/Utils/SwiftType.swift
+++ b/Sources/MockoloFramework/Utils/SwiftType.swift
@@ -87,7 +87,9 @@ struct SwiftType: Equatable, CustomStringConvertible {
 
             switch nominal.name {
             case .optionalTypeSugarName where nominal.genericParameterTypes.count == 1:
-                repr += "\(nominal.genericParameterTypes[0])?"
+                // For an IUO (`T!`, stored as Optional<T> + isIUO) the `!` is appended by the isIUO
+                // block below; emitting `?` here too would wrongly render `T?!`.
+                repr += "\(nominal.genericParameterTypes[0])\(isIUO ? "" : "?")"
             case .arrayTypeSugarName where nominal.genericParameterTypes.count == 1:
                 repr += "[\(nominal.genericParameterTypes[0])]"
             case .dictionaryTypeSugarName where nominal.genericParameterTypes.count == 2:
@@ -476,11 +478,19 @@ struct SwiftType: Equatable, CustomStringConvertible {
             returnTypeCast = " as! " + .`Self`
         }
 
+        // `!` (IUO) is illegal inside a closure type, so an IUO param/return must render as a plain
+        // optional here (it still witnesses the IUO requirement). Clearing `isIUO` is a no-op for
+        // every non-IUO type, so existing handlers are unaffected.
+        displayableReturnType.isIUO = false
         var resultType = SwiftType(
             kind: .closure(.init(
                 isAsync: isAsync,
                 throwing: throwing,
-                arguments: params.map { .init(type: $0.processTypeParams(with: typeParams)) },
+                arguments: params.map {
+                    var argType = $0.processTypeParams(with: typeParams)
+                    argType.isIUO = false
+                    return .init(type: argType)
+                },
                 returning: displayableReturnType
             ))
         )

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -35,6 +35,42 @@ import MockoloFramework
     }
 }
 
+// IUO func/subscript params and returns: the synthesized handler closure renders `Int?` (IUO is
+// illegal inside a closure type), while the signature keeps `Int!` and conforms.
+@Fixture enum iuoFuncs {
+    /// @mockable
+    public protocol IUOFunc {
+        func f(x: Int!) -> Int!
+        subscript(i: Int) -> Int! { get }
+    }
+
+    @Fixture enum expected {
+        public class IUOFuncMock: IUOFunc {
+            public init() { }
+            public private(set) var fCallCount = 0
+            public var fHandler: ((Int?) -> Int?)?
+            public func f(x: Int!) -> Int! {
+                fCallCount += 1
+                if let fHandler = fHandler {
+                    return fHandler(x)
+                }
+                return nil
+            }
+            public private(set) var subscriptCallCount = 0
+            public var subscriptHandler: ((Int) -> Int?)?
+            public subscript(i: Int) -> Int! {
+                get {
+                subscriptCallCount += 1
+                if let subscriptHandler = subscriptHandler {
+                    return subscriptHandler(i)
+                }
+                return nil
+                }
+            }
+        }
+    }
+}
+
 @Fixture enum subscripts {
     /// @mockable
     protocol SubscriptProtocol {

--- a/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FixtureNonSimpleFuncs.swift
@@ -35,20 +35,18 @@ import MockoloFramework
     }
 }
 
-// IUO func/subscript params and returns: the synthesized handler closure renders `Int?` (IUO is
-// illegal inside a closure type), while the signature keeps `Int!` and conforms.
 @Fixture enum iuoFuncs {
     /// @mockable
     public protocol IUOFunc {
         func f(x: Int!) -> Int!
-        subscript(i: Int) -> Int! { get }
+        subscript(i: Int!) -> Int! { get }
     }
 
     @Fixture enum expected {
         public class IUOFuncMock: IUOFunc {
             public init() { }
             public private(set) var fCallCount = 0
-            public var fHandler: ((Int?) -> Int?)?
+            public var fHandler: ((Int) -> Int)?
             public func f(x: Int!) -> Int! {
                 fCallCount += 1
                 if let fHandler = fHandler {
@@ -57,8 +55,8 @@ import MockoloFramework
                 return nil
             }
             public private(set) var subscriptCallCount = 0
-            public var subscriptHandler: ((Int) -> Int?)?
-            public subscript(i: Int) -> Int! {
+            public var subscriptHandler: ((Int) -> Int)?
+            public subscript(i: Int!) -> Int! {
                 get {
                 subscriptCallCount += 1
                 if let subscriptHandler = subscriptHandler {

--- a/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
+++ b/Tests/TestFuncs/TestBasicFuncs/FuncBasicTests.swift
@@ -9,6 +9,11 @@ class BasicFuncTests: MockoloTestCase {
                dstContent: subscripts.expected._source)
     }
 
+    func testIUOFuncs() {
+        verify(srcContent: iuoFuncs._source,
+               dstContent: iuoFuncs.expected._source)
+    }
+
     func testGetOnlySubscripts() {
         verify(srcContent: getOnlySubscripts._source,
                dstContent: getOnlySubscripts.expected._source)

--- a/Tests/TestVars/FixtureNonSimpleVars.swift
+++ b/Tests/TestVars/FixtureNonSimpleVars.swift
@@ -48,7 +48,6 @@ import MockoloFramework
     }
 }
 
-// An implicitly-unwrapped optional property renders as `Int!` (not `Int?!`) and conforms.
 @Fixture enum iuoVars {
     /// @mockable
     public protocol IUOVar {

--- a/Tests/TestVars/FixtureNonSimpleVars.swift
+++ b/Tests/TestVars/FixtureNonSimpleVars.swift
@@ -47,3 +47,25 @@ import MockoloFramework
         }
     }
 }
+
+// An implicitly-unwrapped optional property renders as `Int!` (not `Int?!`) and conforms.
+@Fixture enum iuoVars {
+    /// @mockable
+    public protocol IUOVar {
+        var a: Int! { get }
+        var b: Int! { get set }
+    }
+
+    @Fixture enum expected {
+        public class IUOVarMock: IUOVar {
+            public init() { }
+            public init(a: Int! = nil, b: Int! = nil) {
+                self.a = a
+                self.b = b
+            }
+            public var a: Int! = nil
+            public private(set) var bSetCallCount = 0
+            public var b: Int! = nil { didSet { bSetCallCount += 1 } }
+        }
+    }
+}

--- a/Tests/TestVars/VarTests.swift
+++ b/Tests/TestVars/VarTests.swift
@@ -21,6 +21,11 @@ class VarTests: MockoloTestCase {
                allowSetCallCount: true)
     }
 
+    func testIUOVars() {
+        verify(srcContent: iuoVars._source,
+               dstContent: iuoVars.expected._source)
+    }
+
 #if compiler(>=6.0)
     func testAsyncThrows() {
         verify(srcContent: asyncThrowsVars._source,


### PR DESCRIPTION
## Summary

Split out of #353 per review. Mockolo renders an implicitly-unwrapped optional (`T!`) as `T?!` (≈ `T??`), which doesn't satisfy the `T!` (≡ `T?`) protocol requirement — so the generated mock fails to conform.

```swift
// before:  public var x: Int?!   ❌ does not conform
// after:   public var x: Int!    ✅
```

Fixed for properties, function/subscript params & returns, and generic returns. For func/subscript handlers the synthesized closure renders `((Int?) -> Int?)?` (since `!` is illegal inside a closure type) while the signature keeps `Int!`. Inert for non-IUO types — no existing fixture output changes.

## Test plan

New `iuoVars` / `iuoFuncs` compiled `@Fixture` mocks (conformance is compiler-enforced). `swift build && swift test` green.

---
#353 carries an extra getter-on-IUO edge test that depends on this fix, so this should land first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
