### PR TITLE
Skip directories while scanning Swift sources

### DIFF
--- a/Sources/MockoloFramework/Utils/FileScanner.swift
+++ b/Sources/MockoloFramework/Utils/FileScanner.swift
@@ -132,12 +132,33 @@ public func scanDirs(_ paths: [String], with callBack: (String) -> Void) {
 }
 
 func scanDir(_ path: String, with callBack: (String) -> Void) {
+    let resourceKeys: Set<URLResourceKey> = [.isDirectoryKey, .isSymbolicLinkKey]
     let errorHandler = { (url: URL, error: Error) -> Bool in
         fatalError("Failed to traverse \(url) with error \(error).")
     }
-    if let enumerator = FileManager.default.enumerator(at: URL(fileURLWithPath: path, isDirectory: true), includingPropertiesForKeys: nil, options: [.skipsHiddenFiles], errorHandler: errorHandler) {
+    let directoryURL = URL(fileURLWithPath: path, isDirectory: true)
+    if let enumerator = FileManager.default.enumerator(
+        at: directoryURL,
+        includingPropertiesForKeys: Array(resourceKeys),
+        options: [.skipsHiddenFiles],
+        errorHandler: errorHandler
+    ) {
         while let nextObjc = enumerator.nextObject() {
             if let fileUrl = nextObjc as? URL {
+                let resourceValues: URLResourceValues
+                do {
+                    resourceValues = try fileUrl.resourceValues(forKeys: resourceKeys)
+                } catch {
+                    fatalError("Failed to retrieve attributes of \(fileUrl) with error \(error).")
+                }
+                guard resourceValues.isDirectory == false else { continue }
+                if resourceValues.isSymbolicLink == true {
+                    var targetIsDirectory: ObjCBool = false
+                    guard FileManager.default.fileExists(
+                        atPath: fileUrl.path,
+                        isDirectory: &targetIsDirectory
+                    ), !targetIsDirectory.boolValue else { continue }
+                }
                 callBack(fileUrl.path)
             }
         }

--- a/Tests/TestFileScanner.swift/FileScannerTests.swift
+++ b/Tests/TestFileScanner.swift/FileScannerTests.swift
@@ -1,0 +1,60 @@
+import Foundation
+import MockoloFramework
+import XCTest
+
+final class FileScannerTests: XCTestCase {
+    func testDirectoryWithSwiftSuffixIsNotReturnedAsSourceFile() {
+        let testFile = URL(fileURLWithPath: #filePath)
+        let swiftSuffixDirectory = testFile.deletingLastPathComponent()
+        let testsDirectory = swiftSuffixDirectory.deletingLastPathComponent()
+        var scannedPaths = [String]()
+
+        scan(dirs: [testsDirectory.path], numThreads: 1) { path, _ in
+            scannedPaths.append(path)
+        }
+
+        XCTAssertTrue(scannedPaths.contains(testFile.path))
+        XCTAssertFalse(scannedPaths.contains(swiftSuffixDirectory.path))
+    }
+
+    func testSymbolicLinkToDirectoryIsNotReturnedAsSourceFile() throws {
+        let fixtureDirectory = FileManager.default.temporaryDirectory
+            .resolvingSymlinksInPath()
+            .appendingPathComponent(
+                "MockoloFileScannerTests-\(UUID().uuidString)",
+                isDirectory: true
+            )
+        let targetDirectory = fixtureDirectory.appendingPathComponent(
+            "DirectoryTarget",
+            isDirectory: true
+        )
+        let targetFile = targetDirectory.appendingPathComponent("File.swift")
+        let directoryLink = fixtureDirectory.appendingPathComponent("DirectoryLink.swift")
+        let fileLink = fixtureDirectory.appendingPathComponent("FileLink.swift")
+
+        try FileManager.default.createDirectory(
+            at: targetDirectory,
+            withIntermediateDirectories: true
+        )
+        XCTAssertTrue(FileManager.default.createFile(atPath: targetFile.path, contents: nil))
+        try FileManager.default.createSymbolicLink(
+            atPath: directoryLink.path,
+            withDestinationPath: targetDirectory.path
+        )
+        try FileManager.default.createSymbolicLink(
+            atPath: fileLink.path,
+            withDestinationPath: targetFile.path
+        )
+
+        var scannedPaths = [String]()
+        scan(dirs: [fixtureDirectory.path], numThreads: 1) { path, _ in
+            scannedPaths.append(path)
+        }
+        let scannedFileNames = Set(scannedPaths.map {
+            URL(fileURLWithPath: $0).lastPathComponent
+        })
+
+        XCTAssertEqual(scannedFileNames, [targetFile.lastPathComponent, fileLink.lastPathComponent])
+        XCTAssertFalse(scannedFileNames.contains(directoryLink.lastPathComponent))
+    }
+}


### PR DESCRIPTION
## Summary

- inspect enumerated resource types before passing paths to the source parser
- skip real directories and symlinks to directories while preserving symlinks to files
- add regressions for `.swift`-suffixed directories and directory/file symlink boundaries

Fixes #356

## Testing

- `swift test --filter FileScannerTests` (2 tests)
- `swift test` (158 XCTest tests and 3 Swift Testing tests)
- `swift build`
- `swift run mockolo -j 4 -s .build/issue-356-reproduction/Sources -d .build/issue-356-reproduction/Generated-swift-run.swift`