### PR TITLE
Correct the documented default concurrency limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,7 +142,7 @@ OPTIONS:
   --annotation <annotation>
                           A custom annotation string used to indicate if a type should be mocked (default = @mockable). (default: @mockable)
   -j, --concurrency-limit <n>
-                          Maximum number of threads to execute concurrently (default = number of cores on the running machine).
+                          Maximum number of threads to execute concurrently (default = 1).
   --custom-imports <custom-imports>
                           If set, custom module imports (separated by a space) will be added to the final import statement list.
   --enable-args-history   Whether to enable args history for all functions (default = false). To enable history per function, use the 'history' keyword in the annotation argument.
@@ -456,4 +456,3 @@ Mockolo is licensed under Apache License 2.0. See [LICENSE](LICENSE.txt) for mor
     WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
     See the License for the specific language governing permissions and
     limitations under the License.
-

--- a/Sources/Mockolo/Executor.swift
+++ b/Sources/Mockolo/Executor.swift
@@ -34,7 +34,7 @@ struct Executor: ParsableCommand {
 
     @Option(name: [.customShort("j"), .long],
             help: ArgumentHelp(
-                "Maximum number of threads to execute concurrently (default = number of cores on the running machine).",
+                "Maximum number of threads to execute concurrently (default = 1).",
                 valueName: "n"))
     private var concurrencyLimit: Int?
 


### PR DESCRIPTION
## Summary

- Correct the `--concurrency-limit` help text to document the actual default of `1`.
- Keep the README command reference consistent with the CLI output.

## Background

`concurrencyLimit` is optional, and the scanner falls back to `1` when no value is provided. The existing help text incorrectly states that the default is the number of cores on the running machine.

## Testing

- `swift test`
- Verified that `.build/debug/mockolo --help` reports `(default = 1)`.
